### PR TITLE
feat: client-initiated recipe image generation with skeleton loading

### DIFF
--- a/packages/api/src/domain/RecipeImageService/index.ts
+++ b/packages/api/src/domain/RecipeImageService/index.ts
@@ -10,15 +10,22 @@ export class RecipeImageService {
         private readonly logger?: Logger
     ) {}
 
-    async generateRecipeImage(recipeId: string, title: string, ingredients: Ingredient[]): Promise<string> {
+    async generateRecipeImage(
+        recipeId: string,
+        title: string,
+        ingredients: Ingredient[],
+        force = false
+    ): Promise<string> {
         const key = `recipe-images/${recipeId}`;
 
-        try {
-            await this.store.getHeadObject(key);
-            this.logger?.info('Recipe image already exists in store', { recipeId });
-            return key;
-        } catch {
-            this.logger?.info('Recipe image not found in store, generating', { recipeId });
+        if (!force) {
+            try {
+                await this.store.getHeadObject(key);
+                this.logger?.info('Recipe image already exists in store', { recipeId });
+                return key;
+            } catch {
+                this.logger?.info('Recipe image not found in store, generating', { recipeId });
+            }
         }
 
         const prompt = this.generatePrompt(title, ingredients);

--- a/packages/api/src/domain/RecipeService/index.test.ts
+++ b/packages/api/src/domain/RecipeService/index.test.ts
@@ -116,33 +116,41 @@ beforeEach(() => {
     mockImageService.reset();
 });
 
-describe('RecipeService.createRecipe image enrichment', () => {
-    it('fires background image enrichment when recipeImageService provided', async () => {
+describe('RecipeService.regenerateImage', () => {
+    it('generates image when coverImageKey is not set', async () => {
         const svc = new RecipeService(repo as any, ids, undefined, undefined, mockImageService as any);
-        const recipe = await svc.createRecipe('Pasta', [{ id: '1', name: 'flour' }], owner.id, owner);
+        const created = await svc.createRecipe('Pasta', [{ id: '1', name: 'flour' }], owner.id, owner);
 
-        await new Promise((r) => setTimeout(r, 10));
+        const result = await svc.regenerateImage(created.id, owner.id);
 
         expect(mockImageService.calls.length).toBe(1);
-        expect(mockImageService.calls[0].recipeId).toBe(recipe.id);
-        expect(mockImageService.calls[0].title).toBe('Pasta');
-        expect(repo.store.get(recipe.id)?.coverImageKey).toBe(`recipe-images/${recipe.id}`);
+        expect(mockImageService.calls[0].recipeId).toBe(created.id);
+        expect(result.coverImageKey).toBe(`recipe-images/${created.id}`);
     });
 
-    it('skips enrichment when no recipeImageService provided', async () => {
-        const svc = new RecipeService(repo as any, ids);
-        await svc.createRecipe('Pasta', [], owner.id, owner);
+    it('returns existing recipe without generating when coverImageKey already set', async () => {
+        const svc = new RecipeService(repo as any, ids, undefined, undefined, mockImageService as any);
+        const created = await svc.createRecipe('Pasta', [], owner.id, owner);
+        await svc.setCoverImageKey(created.id, 'existing-key', owner.id);
 
-        await new Promise((r) => setTimeout(r, 10));
+        const result = await svc.regenerateImage(created.id, owner.id);
 
         expect(mockImageService.calls.length).toBe(0);
+        expect(result.coverImageKey).toBe('existing-key');
     });
 
-    it('does not throw when enrichment fails', async () => {
-        mockImageService.shouldReject = true;
-        const svc = new RecipeService(repo as any, ids, undefined, undefined, mockImageService as any);
+    it('throws 503 when image service not configured', async () => {
+        const svc = new RecipeService(repo as any, ids);
+        const created = await svc.createRecipe('Pasta', [], owner.id, owner);
 
-        await expect(svc.createRecipe('Pasta', [], owner.id, owner)).resolves.toBeDefined();
+        await expect(svc.regenerateImage(created.id, owner.id)).rejects.toMatchObject({ status: 503 });
+    });
+
+    it('throws 403 when non-owner tries to regenerate', async () => {
+        const svc = new RecipeService(repo as any, ids, undefined, undefined, mockImageService as any);
+        const created = await svc.createRecipe('Pasta', [], owner.id, owner);
+
+        await expect(svc.regenerateImage(created.id, 'other-user')).rejects.toMatchObject({ status: 403 });
     });
 });
 

--- a/packages/api/src/domain/RecipeService/index.ts
+++ b/packages/api/src/domain/RecipeService/index.ts
@@ -46,7 +46,6 @@ export class RecipeService {
                 owner: owner.username,
                 ingredientCount: created.ingredients.length,
             });
-            void this.enrichRecipeImage(created.id, title, ingredients);
             return created;
         } catch (error) {
             this.logger?.error('Failed to create recipe', {
@@ -198,15 +197,24 @@ export class RecipeService {
         }
     }
 
-    private async enrichRecipeImage(recipeId: string, title: string, ingredients: Ingredient[]): Promise<void> {
-        if (!this.recipeImageService) return;
-        try {
-            const key = await this.recipeImageService.generateRecipeImage(recipeId, title, ingredients);
-            await this.recipeRepository.setCoverImageKey(recipeId, key);
-            this.logger?.info('Recipe image enrichment complete', { recipeId, key });
-        } catch (error) {
-            this.logger?.error('Recipe image enrichment failed', { recipeId, error });
+    async regenerateImage(recipeId: string, userId: string): Promise<Recipe> {
+        if (!this.recipeImageService) {
+            const error = new Error('Image service not configured');
+            Object.assign(error, { status: 503 });
+            throw error;
         }
+        const recipe = await this.getRecipe(recipeId);
+        if (!this.authorizationService.isListOwner(recipe, userId)) {
+            const error = new Error('Only recipe owner can regenerate image');
+            Object.assign(error, { status: 403 });
+            throw error;
+        }
+        if (recipe.coverImageKey) {
+            return recipe;
+        }
+        const key = await this.recipeImageService.generateRecipeImage(recipeId, recipe.title, recipe.ingredients, true);
+        await this.recipeRepository.setCoverImageKey(recipeId, key);
+        return this.getRecipe(recipeId);
     }
 
     async setCoverImageKey(recipeId: string, coverImageKey: string, userId: string): Promise<Recipe> {

--- a/packages/api/src/interfaces/RecipeHandlers/index.ts
+++ b/packages/api/src/interfaces/RecipeHandlers/index.ts
@@ -584,3 +584,48 @@ export const uploadRecipeImage = async (ctx: Context): Promise<void> => {
         ctx.body = { error: errorMessage };
     }
 };
+
+export const generateRecipeImage = async (ctx: Context): Promise<void> => {
+    const { recipeId } = ctx.params as { recipeId: string };
+    const logger = getLogger();
+    const authenticatedUser = getAuthenticatedUser(ctx);
+
+    if (!authenticatedUser) {
+        ctx.status = 401;
+        ctx.body = { error: 'Unauthorized' };
+        return;
+    }
+
+    try {
+        const hasAccess = await verifyRecipeAccess(recipeId, authenticatedUser, ctx);
+        if (!hasAccess) {
+            ctx.status = 403;
+            ctx.body = { error: 'Forbidden' };
+            return;
+        }
+
+        const recipe = await getRecipeService().regenerateImage(recipeId, authenticatedUser.id);
+
+        logger.info('API: Recipe image generated', {
+            userId: authenticatedUser.id,
+            recipeId,
+        });
+
+        ctx.status = 200;
+        ctx.body = recipe;
+    } catch (error: unknown) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        const status = (error as HttpError)?.status ?? 500;
+        const errorMessage = err.message || 'Internal Server Error';
+
+        logger.error('API: Failed to generate recipe image', {
+            userId: authenticatedUser.id,
+            recipeId,
+            error: errorMessage,
+            status,
+        });
+
+        ctx.status = status;
+        ctx.body = { error: errorMessage };
+    }
+};

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -59,5 +59,6 @@ router.delete('/api/recipes/:recipeId/users/:targetUserId', authenticate, (ctx) 
 );
 router.put('/api/recipes/:recipeId/image', authenticate, (ctx) => recipeHandlers.setCoverImageKey(ctx));
 router.post('/api/recipes/:recipeId/image/upload', authenticate, (ctx) => recipeHandlers.uploadRecipeImage(ctx));
+router.post('/api/recipes/:recipeId/image/generate', authenticate, (ctx) => recipeHandlers.generateRecipeImage(ctx));
 
 export default router;

--- a/packages/web/src/api/index.ts
+++ b/packages/web/src/api/index.ts
@@ -343,6 +343,14 @@ export const deleteCoverImageKey = async (recipeId: string): Promise<Recipe> => 
     });
 };
 
+export const generateRecipeAiImage = async (recipeId: string): Promise<Recipe> => {
+    return await makeRequest({
+        pathname: `/api/recipes/${encodeURIComponent(recipeId)}/image/generate`,
+        method: MethodType.POST,
+        operationString: 'generate recipe ai image',
+    });
+};
+
 export const uploadRecipeImage = async (recipeId: string, file: File): Promise<{ imageKey: string }> => {
     const formData = new FormData();
     formData.append('image', file);

--- a/packages/web/src/components/RecipeCard/index.tsx
+++ b/packages/web/src/components/RecipeCard/index.tsx
@@ -1,17 +1,17 @@
 import { getStorageItem } from '@imapps/web-utils';
 import type { Recipe } from '@shoppingo/types';
-import { ImageOff, Loader2, Pizza } from 'lucide-react';
+import { ImageOff } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Card, CardContent } from '../../components/ui/card';
+import { Skeleton } from '../../components/ui/skeleton';
 import { getAuthConfig } from '../../config/auth';
 
 interface RecipeCardProps {
     recipe: Recipe;
     onClick: () => void;
-    isGeneratingImage?: boolean;
 }
 
-export const RecipeCard = ({ recipe, onClick, isGeneratingImage = false }: RecipeCardProps) => {
+export const RecipeCard = ({ recipe, onClick }: RecipeCardProps) => {
     const [imageUrl, setImageUrl] = useState<string | null>(null);
     const [isLoadingImage, setIsLoadingImage] = useState(() => !!recipe.coverImageKey);
     const [hasImageError, setHasImageError] = useState(false);
@@ -89,35 +89,13 @@ export const RecipeCard = ({ recipe, onClick, isGeneratingImage = false }: Recip
                     />
                 )}
 
-                {isLoadingImage && !imageUrl && (
-                    <div className="absolute inset-0 flex items-center justify-center bg-muted/50">
-                        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                    </div>
+                {(isLoadingImage || !recipe.coverImageKey) && !imageUrl && !hasImageError && (
+                    <Skeleton className="absolute inset-0 h-full w-full rounded-none" />
                 )}
 
                 {hasImageError && (
                     <div className="absolute inset-0 flex items-center justify-center bg-muted/20 text-muted-foreground">
                         <ImageOff className="h-8 w-8" />
-                    </div>
-                )}
-
-                {isGeneratingImage && !imageUrl && !isLoadingImage && !hasImageError && (
-                    <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-muted/40 to-muted/60">
-                        <Pizza
-                            role="img"
-                            className="h-10 w-10 text-muted-foreground/60 animate-pulse"
-                            aria-label="Generating recipe image"
-                        />
-                    </div>
-                )}
-
-                {!isGeneratingImage && !imageUrl && !isLoadingImage && !hasImageError && (
-                    <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-muted/40 to-muted/60">
-                        <div className="text-center">
-                            <div className="h-10 w-10 mx-auto rounded-full bg-muted-foreground/20 flex items-center justify-center">
-                                <span className="text-2xl">🍳</span>
-                            </div>
-                        </div>
                     </div>
                 )}
             </div>

--- a/packages/web/src/components/RecipesList/index.tsx
+++ b/packages/web/src/components/RecipesList/index.tsx
@@ -7,10 +7,9 @@ interface RecipesListProps {
     recipes: Recipe[];
     onRecipeClick: (recipeId: string) => void;
     isLoading?: boolean;
-    generatingImageIds?: Set<string>;
 }
 
-export const RecipesList = ({ recipes, onRecipeClick, isLoading, generatingImageIds }: RecipesListProps) => {
+export const RecipesList = ({ recipes, onRecipeClick, isLoading }: RecipesListProps) => {
     if (isLoading) {
         return (
             <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 px-2">
@@ -43,12 +42,7 @@ export const RecipesList = ({ recipes, onRecipeClick, isLoading, generatingImage
     return (
         <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 px-2">
             {recipes.map((recipe) => (
-                <RecipeCard
-                    key={recipe.id}
-                    recipe={recipe}
-                    onClick={() => onRecipeClick(recipe.id)}
-                    isGeneratingImage={generatingImageIds?.has(recipe.id) ?? false}
-                />
+                <RecipeCard key={recipe.id} recipe={recipe} onClick={() => onRecipeClick(recipe.id)} />
             ))}
         </div>
     );

--- a/packages/web/src/components/ToolBar/AddRecipeDrawer/index.tsx
+++ b/packages/web/src/components/ToolBar/AddRecipeDrawer/index.tsx
@@ -1,7 +1,7 @@
 import { ChefHat, Image as ImageIcon, Plus, X } from 'lucide-react';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { setCoverImageKey, uploadRecipeImage } from '../../../api';
+import { uploadRecipeImage } from '../../../api';
 import { SearchResults } from '../../../components/SearchResults';
 import { useSearch } from '../../../hooks/useSearch';
 import { Badge } from '../../ui/badge';
@@ -40,9 +40,6 @@ export interface AddRecipeDrawerProps {
         link?: string,
         instructions?: string[]
     ) => Promise<Recipe | undefined>;
-    onRefetch?: () => Promise<void>;
-    onImageGenerating?: (recipeId: string) => void;
-    onImageReady?: (recipeId: string) => void;
     placeholder?: string;
     initialLink?: string;
 }
@@ -53,15 +50,7 @@ const splitIntoSteps = (text: string): string[] =>
         .map((line) => line.replace(/^\s*\d+[.)]\s*/, '').trim())
         .filter(Boolean);
 
-export const AddRecipeDrawer = ({
-    open,
-    onOpenChange,
-    onAdd,
-    onRefetch,
-    onImageGenerating,
-    onImageReady,
-    initialLink,
-}: AddRecipeDrawerProps) => {
+export const AddRecipeDrawer = ({ open, onOpenChange, onAdd, initialLink }: AddRecipeDrawerProps) => {
     const recipeNameId = useId();
     const userSearchId = useId();
     const fileInputId = useId();
@@ -134,46 +123,14 @@ export const AddRecipeDrawer = ({
                 throw new Error('Failed to create recipe');
             }
 
-            const capturedTitle = title;
             const capturedFile = selectedFile;
 
             handleCancel();
 
             if (capturedFile) {
-                onImageGenerating?.(recipe.id);
-                void (async () => {
-                    try {
-                        await uploadRecipeImage(recipe.id, capturedFile);
-                        toast.success('Recipe image uploaded', {
-                            style: { backgroundColor: '#10b981', color: '#ffffff' },
-                        });
-                    } catch {
-                        // silent — recipe still usable
-                    } finally {
-                        onImageReady?.(recipe.id);
-                        if (onRefetch) await onRefetch();
-                    }
-                })();
-            } else {
-                onImageGenerating?.(recipe.id);
-                void (async () => {
-                    try {
-                        const response = await fetch(`/api/image/${encodeURIComponent(capturedTitle)}`, {
-                            method: 'GET',
-                        });
-                        if (response.ok) {
-                            await setCoverImageKey(recipe.id, capturedTitle.trim().toLowerCase());
-                            toast.success('Recipe image generated', {
-                                style: { backgroundColor: '#10b981', color: '#ffffff' },
-                            });
-                        }
-                    } catch {
-                        // silent — recipe still usable
-                    } finally {
-                        onImageReady?.(recipe.id);
-                        if (onRefetch) await onRefetch();
-                    }
-                })();
+                void uploadRecipeImage(recipe.id, capturedFile).catch(() => {
+                    // silent — recipe still usable
+                });
             }
         } catch (err) {
             const message = err instanceof Error ? err.message : 'Failed to create recipe';

--- a/packages/web/src/components/ToolBar/index.tsx
+++ b/packages/web/src/components/ToolBar/index.tsx
@@ -31,9 +31,6 @@ interface ToolBarProps {
         link?: string,
         instructions?: string[]
     ) => Promise<Recipe | undefined>;
-    onRefetchRecipes?: () => Promise<void>;
-    onImageGenerating?: (recipeId: string) => void;
-    onImageReady?: (recipeId: string) => void;
     addRecipeDrawerOpen?: boolean;
     onAddRecipeDrawerOpenChange?: (open: boolean) => void;
     addRecipeInitialLink?: string;
@@ -59,9 +56,6 @@ const ToolBar = ({
     onAddItem,
     onAddIngredient,
     onAddRecipe,
-    onRefetchRecipes,
-    onImageGenerating,
-    onImageReady,
     addRecipeDrawerOpen,
     onAddRecipeDrawerOpenChange,
     addRecipeInitialLink,
@@ -243,9 +237,6 @@ const ToolBar = ({
                                             open={addRecipeDrawerOpen ?? isAddRecipeDrawerOpen}
                                             onOpenChange={onAddRecipeDrawerOpenChange ?? setIsAddRecipeDrawerOpen}
                                             onAdd={onAddRecipe}
-                                            onRefetch={onRefetchRecipes}
-                                            onImageGenerating={onImageGenerating}
-                                            onImageReady={onImageReady}
                                             placeholder={placeholder}
                                             initialLink={addRecipeInitialLink}
                                         />

--- a/packages/web/src/pages/RecipeDetailPage/CoverImageSection.tsx
+++ b/packages/web/src/pages/RecipeDetailPage/CoverImageSection.tsx
@@ -1,10 +1,11 @@
 import { getStorageItem } from '@imapps/web-utils';
 import type { Recipe } from '@shoppingo/types';
-import { ImageIcon, ImageOff, Loader2, Sparkles } from 'lucide-react';
+import { ImageIcon, ImageOff } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { setCoverImageKey, uploadRecipeImage } from '../../api';
+import { uploadRecipeImage } from '../../api';
 import { Button } from '../../components/ui/button';
+import { Skeleton } from '../../components/ui/skeleton';
 import { getAuthConfig } from '../../config/auth';
 
 interface CoverImageSectionProps {
@@ -27,6 +28,8 @@ export const CoverImageSection = ({ recipe, isOwner = false, onImageChange }: Co
             setIsLoadingImage(false);
             return;
         }
+
+        setIsLoadingImage(true);
 
         const fetchImage = async () => {
             try {
@@ -91,39 +94,14 @@ export const CoverImageSection = ({ recipe, isOwner = false, onImageChange }: Co
         }
     };
 
-    const handleAiGenerate = async () => {
-        setIsUploading(true);
-        try {
-            // Trigger AI generation via existing endpoint
-            await fetch(`/api/image/${encodeURIComponent(recipe.title)}`, {
-                method: 'GET',
-            });
-            // Set the imageKey to the normalized title
-            await setCoverImageKey(recipe.id, recipe.title.trim().toLowerCase());
-            toast.success('Image generated successfully', { style: { backgroundColor: '#10b981', color: '#ffffff' } });
-            // Refresh the image
-            if (onImageChange) {
-                onImageChange();
-            }
-        } catch (err) {
-            const message = err instanceof Error ? err.message : 'Failed to generate image';
-            toast.error(message, { style: { backgroundColor: '#ef4444', color: '#ffffff' } });
-        } finally {
-            setIsUploading(false);
-        }
-    };
-
     return (
         <div className="relative h-64 w-full rounded-md overflow-hidden bg-muted border flex items-center justify-center">
             {imageUrl && !hasImageError && (
                 <img src={imageUrl} alt={recipe.title} className="h-full w-full object-cover" />
             )}
 
-            {isLoadingImage && !imageUrl && (
-                <div className="flex flex-col items-center justify-center gap-2">
-                    <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-                    <p className="text-sm text-muted-foreground">Loading image...</p>
-                </div>
+            {(isLoadingImage || !recipe.coverImageKey) && !imageUrl && !hasImageError && (
+                <Skeleton className="absolute inset-0 h-full w-full rounded-none" />
             )}
 
             {hasImageError && (
@@ -133,45 +111,27 @@ export const CoverImageSection = ({ recipe, isOwner = false, onImageChange }: Co
                 </div>
             )}
 
-            {!imageUrl && !isLoadingImage && !hasImageError && (
-                <div className="flex flex-col items-center justify-center gap-3">
-                    <div className="h-12 w-12 rounded-full bg-muted-foreground/20 flex items-center justify-center">
-                        <span className="text-3xl">🍳</span>
-                    </div>
-                    <p className="text-sm text-muted-foreground">No cover image</p>
-                    {isOwner && (
-                        <div className="flex gap-2 mt-2">
-                            <input
-                                ref={fileInputRef}
-                                type="file"
-                                accept="image/*"
-                                onChange={handleImageSelect}
-                                disabled={isUploading}
-                                className="hidden"
-                                id={fileInputId}
-                            />
-                            <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                onClick={() => fileInputRef.current?.click()}
-                                disabled={isUploading}
-                            >
-                                <ImageIcon className="h-4 w-4 mr-1" />
-                                Upload
-                            </Button>
-                            <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                disabled={isUploading}
-                                onClick={handleAiGenerate}
-                            >
-                                <Sparkles className="h-4 w-4 mr-1" />
-                                AI Generate
-                            </Button>
-                        </div>
-                    )}
+            {!recipe.coverImageKey && isOwner && (
+                <div className="absolute bottom-3 right-3 z-10">
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*"
+                        onChange={handleImageSelect}
+                        disabled={isUploading}
+                        className="hidden"
+                        id={fileInputId}
+                    />
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={isUploading}
+                    >
+                        <ImageIcon className="h-4 w-4 mr-1" />
+                        Upload
+                    </Button>
                 </div>
             )}
         </div>

--- a/packages/web/src/pages/RecipesPage/index.tsx
+++ b/packages/web/src/pages/RecipesPage/index.tsx
@@ -1,9 +1,9 @@
 import { useUser } from '@imapps/web-utils';
 import { AlertTriangle, BookOpen, ChefHat, Search, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { useQuery } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { addRecipe, getRecipesQuery } from '../../api';
+import { addRecipe, generateRecipeAiImage, getRecipesQuery } from '../../api';
 import { ListsSkeleton } from '../../components/LoadingSkeleton';
 import { RecipesList } from '../../components/RecipesList';
 import ToolBar from '../../components/ToolBar';
@@ -16,11 +16,11 @@ import { logger } from '../../utils/logger';
 const RecipesPage = () => {
     const { user } = useUser();
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
     const [searchParams, setSearchParams] = useSearchParams();
     const [drawerOpen, setDrawerOpen] = useState(false);
     const [sharedUrl, setSharedUrl] = useState('');
     const [searchQuery, setSearchQuery] = useState('');
-    const [generatingImageIds, setGeneratingImageIds] = useState<Set<string>>(new Set());
     const { data, isLoading, isError, refetch } = useQuery({
         ...getRecipesQuery(user?.id || ''),
         enabled: !!user?.id,
@@ -57,18 +57,6 @@ const RecipesPage = () => {
     const recipes = data || [];
     const searchResults = useRecipeSearch(recipes, searchQuery);
 
-    const handleImageGenerating = (recipeId: string) => {
-        setGeneratingImageIds((prev) => new Set(prev).add(recipeId));
-    };
-
-    const handleImageReady = (recipeId: string) => {
-        setGeneratingImageIds((prev) => {
-            const next = new Set(prev);
-            next.delete(recipeId);
-            return next;
-        });
-    };
-
     if (!user?.id) {
         logger.warn('Recipes page accessed without user');
         return <div>User not available</div>;
@@ -98,6 +86,9 @@ const RecipesPage = () => {
             const recipe = await addRecipe(title, user, selectedUsers || [], ingredients, link, instructions);
             logger.info('Recipe created successfully', { title, recipeId: recipe.id });
             await refetch();
+            void generateRecipeAiImage(recipe.id).then(() =>
+                queryClient.invalidateQueries(getRecipesQuery(user.id).queryKey)
+            );
             return recipe;
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -135,11 +126,7 @@ const RecipesPage = () => {
                 <div>
                     <h2 className="text-lg font-semibold mb-3 text-foreground">Results ({searchResults.length})</h2>
                     {searchResults.length > 0 ? (
-                        <RecipesList
-                            recipes={searchResults}
-                            onRecipeClick={handleRecipeClick}
-                            generatingImageIds={generatingImageIds}
-                        />
+                        <RecipesList recipes={searchResults} onRecipeClick={handleRecipeClick} />
                     ) : (
                         <Empty className="flex-none justify-start p-4">
                             <EmptyHeader>
@@ -158,11 +145,7 @@ const RecipesPage = () => {
                     <div>
                         <h2 className="text-lg font-semibold mb-3 text-foreground">Your Recipes</h2>
                         {yourRecipes.length > 0 ? (
-                            <RecipesList
-                                recipes={yourRecipes}
-                                onRecipeClick={handleRecipeClick}
-                                generatingImageIds={generatingImageIds}
-                            />
+                            <RecipesList recipes={yourRecipes} onRecipeClick={handleRecipeClick} />
                         ) : (
                             <Empty className="flex-none justify-start p-4">
                                 <EmptyHeader>
@@ -180,11 +163,7 @@ const RecipesPage = () => {
                     <div>
                         <h2 className="text-lg font-semibold mb-3 text-foreground">Shared Recipes</h2>
                         {sharedRecipes.length > 0 ? (
-                            <RecipesList
-                                recipes={sharedRecipes}
-                                onRecipeClick={handleRecipeClick}
-                                generatingImageIds={generatingImageIds}
-                            />
+                            <RecipesList recipes={sharedRecipes} onRecipeClick={handleRecipeClick} />
                         ) : (
                             <Empty className="flex-none justify-start p-4">
                                 <EmptyHeader>
@@ -230,9 +209,6 @@ const RecipesPage = () => {
 
             <ToolBar
                 onAddRecipe={handleAddRecipe}
-                onRefetchRecipes={refetch}
-                onImageGenerating={handleImageGenerating}
-                onImageReady={handleImageReady}
                 placeholder="Enter recipe name..."
                 addRecipeDrawerOpen={drawerOpen}
                 onAddRecipeDrawerOpenChange={(open) => {


### PR DESCRIPTION
## Summary

- Moves recipe image generation from server-side fire-and-forget to client-initiated: after creating a recipe, the frontend immediately fires `POST /api/recipes/:id/image/generate` independently and invalidates the query cache when it resolves — no polling
- Adds idempotency guard on `regenerateImage`: returns early if `coverImageKey` already set, preventing duplicate OpenAI calls
- Replaces all recipe image placeholder states (pulsing pizza, emoji, spinner) with the same `Skeleton` component used by shopping list items — shown whenever `coverImageKey` is absent
- Removes the entire `isGeneratingImage` prop chain (`generatingImageIds`, `onImageGenerating`, `onImageReady`) across `RecipesPage` → `ToolBar` → `AddRecipeDrawer`
- Removes AI Generate button from `CoverImageSection`; owner retains an Upload button overlaid on the skeleton

## Test plan

- [ ] Create a recipe — card appears immediately with skeleton, image loads ~15s later without any interaction
- [ ] Navigate away and back while image is generating — skeleton still shown, image appears once generation completes
- [ ] Open recipe detail page while image is generating — skeleton shown, owner sees Upload button overlay
- [ ] Upload a custom image — replaces skeleton immediately
- [ ] Create a recipe when OpenAI is unavailable — card shows skeleton indefinitely (no crash)
- [ ] Call generate endpoint on a recipe that already has a `coverImageKey` — returns existing recipe, no OpenAI call made
- [ ] API tests: `bun run --filter @shoppingo/api test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)