### PR TITLE
feat(api): shared AI recipe image cache by title

### DIFF
--- a/packages/api/src/domain/RecipeImageService/index.test.ts
+++ b/packages/api/src/domain/RecipeImageService/index.test.ts
@@ -105,7 +105,7 @@ describe('RecipeImageService', () => {
 
             const key = await service.generateRecipeImage('rec-1', 'Lemon Chicken', ingredients);
 
-            expect(key).toBe('recipe-images/rec-1');
+            expect(key).toBe('recipe-image/lemon chicken');
             expect(mockGenerator.calls.length).toBe(0);
             expect(mockStore.calls.putObject.length).toBe(0);
         });
@@ -115,12 +115,12 @@ describe('RecipeImageService', () => {
 
             const key = await service.generateRecipeImage('rec-2', 'Lemon Chicken', ingredients);
 
-            expect(key).toBe('recipe-images/rec-2');
+            expect(key).toBe('recipe-image/lemon chicken');
             expect(mockGenerator.calls.length).toBe(1);
             expect(mockGenerator.calls[0][0]).toBe(
                 'Appetising food photography of Lemon Chicken, featuring chicken, garlic, lemon, soft natural lighting, shallow depth of field, served on a wooden table, no text, no watermark.'
             );
-            expect(mockStore.calls.putObject[0][0]).toBe('recipe-images/rec-2');
+            expect(mockStore.calls.putObject[0][0]).toBe('recipe-image/lemon chicken');
         });
 
         it('builds prompt with no ingredient clause when ingredients empty', async () => {
@@ -161,7 +161,7 @@ describe('RecipeImageService', () => {
 
             const key = await serviceNoLogger.generateRecipeImage('rec-6', 'Title', ingredients);
 
-            expect(key).toBe('recipe-images/rec-6');
+            expect(key).toBe('recipe-image/title');
         });
     });
 });

--- a/packages/api/src/domain/RecipeImageService/index.ts
+++ b/packages/api/src/domain/RecipeImageService/index.ts
@@ -16,7 +16,7 @@ export class RecipeImageService {
         ingredients: Ingredient[],
         force = false
     ): Promise<string> {
-        const key = `recipe-images/${recipeId}`;
+        const key = `recipe-image/${title.trim().toLowerCase()}`;
 
         if (!force) {
             try {

--- a/packages/api/src/domain/RecipeService/index.test.ts
+++ b/packages/api/src/domain/RecipeService/index.test.ts
@@ -101,7 +101,7 @@ class MockRecipeImageService {
     async generateRecipeImage(recipeId: string, title: string, ingredients: Ingredient[]): Promise<string> {
         this.calls.push({ recipeId, title, ingredients });
         if (this.shouldReject) throw new Error('generation failed');
-        return `recipe-images/${recipeId}`;
+        return `recipe-image/${title.trim().toLowerCase()}`;
     }
 
     reset() {
@@ -125,7 +125,7 @@ describe('RecipeService.regenerateImage', () => {
 
         expect(mockImageService.calls.length).toBe(1);
         expect(mockImageService.calls[0].recipeId).toBe(created.id);
-        expect(result.coverImageKey).toBe(`recipe-images/${created.id}`);
+        expect(result.coverImageKey).toBe('recipe-image/pasta');
     });
 
     it('returns existing recipe without generating when coverImageKey already set', async () => {

--- a/packages/api/src/domain/RecipeService/index.ts
+++ b/packages/api/src/domain/RecipeService/index.ts
@@ -212,7 +212,7 @@ export class RecipeService {
         if (recipe.coverImageKey) {
             return recipe;
         }
-        const key = await this.recipeImageService.generateRecipeImage(recipeId, recipe.title, recipe.ingredients, true);
+        const key = await this.recipeImageService.generateRecipeImage(recipeId, recipe.title, recipe.ingredients);
         await this.recipeRepository.setCoverImageKey(recipeId, key);
         return this.getRecipe(recipeId);
     }

--- a/packages/api/src/interfaces/ImageHandlers/index.ts
+++ b/packages/api/src/interfaces/ImageHandlers/index.ts
@@ -13,8 +13,7 @@ export const getImage = async (ctx: Context) => {
     const logger = getLogger();
 
     try {
-        // Check if it's a stored image key (e.g., recipe-uploads/...)
-        if (name.includes('/')) {
+        if (name.startsWith('recipe-upload/')) {
             // Stored images require authentication
             const user = ctx.state.user as { id: string; username: string } | undefined;
             if (!user?.id) {

--- a/packages/api/src/interfaces/RecipeHandlers/index.test.ts
+++ b/packages/api/src/interfaces/RecipeHandlers/index.test.ts
@@ -485,7 +485,7 @@ describe('RecipeHandlers', () => {
             mockBucketStore.putObject.mockResolvedValue(undefined);
             mockRecipeService.setCoverImageKey.mockResolvedValue({
                 ...baseRecipe,
-                coverImageKey: 'recipe-uploads/user-1/recipe-1',
+                coverImageKey: 'recipe-upload/user-1/recipe-1',
             });
             const ctx = createMockContext({
                 params: { recipeId: 'recipe-1' },

--- a/packages/api/src/interfaces/RecipeHandlers/index.ts
+++ b/packages/api/src/interfaces/RecipeHandlers/index.ts
@@ -550,8 +550,7 @@ export const uploadRecipeImage = async (ctx: Context): Promise<void> => {
         // Read file buffer
         const fileBuffer = await readFile(filePath);
 
-        // Generate unique key: recipe-uploads/{userId}/{recipeId}
-        const imageKey = `recipe-uploads/${authenticatedUser.id}/${recipeId}`;
+        const imageKey = `recipe-upload/${authenticatedUser.id}/${recipeId}`;
 
         // Store in MinIO
         const bucketStore = getBucketStore();

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -35,11 +35,9 @@ router.delete('/api/lists/:title/clearSelected', authenticate, listHandlers.dele
 router.post('/api/lists/:title/users', authenticate, listHandlers.addUserToList);
 router.delete('/api/lists/:title/users/:userId', authenticate, listHandlers.removeUserFromList);
 
-// Conditional auth for images: stored images need auth, AI images don't
 const conditionalImageAuth = async (ctx: Context, next: Next) => {
     const { name } = ctx.params as { name: string };
-    // Only require auth for stored images (contain /)
-    if (name.includes('/')) {
+    if (name.startsWith('recipe-upload/')) {
         return authenticate(ctx, next);
     }
     return next();


### PR DESCRIPTION
## Summary
- AI-generated recipe images now use `recipe-image/{normalised-title}` as the storage key instead of `recipe-image/{recipeId}`, so all users who create a recipe with the same title share one cached image
- User-uploaded images remain private under `recipe-upload/{userId}/{recipeId}`
- Renamed `recipe-uploads/` → `recipe-upload/` for singular REST naming consistency
- Updated `conditionalImageAuth` to only require auth for `recipe-upload/*` keys; shared AI images are now public like shopping list item images

## Test plan
- [ ] All 374 API tests pass
- [ ] Type check clean
- [ ] Lint clean
- [ ] Create two recipes with the same title — second generation should return the cached key without calling OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)