### PR TITLE
fix(web,api): restore skeleton loading and prevent double image generation

### DIFF
--- a/packages/api/src/interfaces/ImageHandlers/index.test.ts
+++ b/packages/api/src/interfaces/ImageHandlers/index.test.ts
@@ -37,12 +37,19 @@ const createMockContext = (overrides: Partial<Context> = {}): Context =>
         ...overrides,
     }) as Context;
 
+const mockBucketStore = {
+    getHeadObject: vi.fn(),
+    getObjectStream: vi.fn(),
+    putObject: vi.fn(),
+};
+
 describe('ImageHandlers', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockDependencyContainer.resolve.mockImplementation((token: string) => {
             if (token === 'ImageService') return mockImageService;
             if (token === 'Logger') return mockLogger;
+            if (token === 'ImageStore') return mockBucketStore;
             return null;
         });
     });
@@ -171,6 +178,34 @@ describe('ImageHandlers', () => {
 
             expect(ctx.status).toBe(500);
             expect(ctx.body).toEqual({ error: 'Stream error' });
+        });
+
+        describe('recipe-image/* keys', () => {
+            it('returns image from bucket without calling ImageService', async () => {
+                const mockStream = { pipe: vi.fn(), on: vi.fn() };
+                mockBucketStore.getHeadObject.mockResolvedValue({ metaData: { 'content-type': 'image/webp' } });
+                mockBucketStore.getObjectStream.mockResolvedValue(mockStream);
+                mockStream.on.mockImplementation((event: string, cb: () => void) => {
+                    if (event === 'end') setTimeout(cb, 0);
+                });
+
+                const ctx = createMockContext({ params: { name: 'recipe-image/pasta' } });
+                await imageHandlers.getImage(ctx);
+
+                expect(mockImageService.getImage).not.toHaveBeenCalled();
+                expect(ctx.status).toBe(200);
+                expect(ctx.set).toHaveBeenCalledWith('Content-Type', 'image/webp');
+            });
+
+            it('returns 404 when recipe image not in bucket', async () => {
+                mockBucketStore.getHeadObject.mockRejectedValue(new Error('Not found'));
+
+                const ctx = createMockContext({ params: { name: 'recipe-image/pasta' } });
+                await imageHandlers.getImage(ctx);
+
+                expect(mockImageService.getImage).not.toHaveBeenCalled();
+                expect(ctx.status).toBe(404);
+            });
         });
 
         it('should handle stream end event', async () => {

--- a/packages/api/src/interfaces/ImageHandlers/index.ts
+++ b/packages/api/src/interfaces/ImageHandlers/index.ts
@@ -52,7 +52,33 @@ export const getImage = async (ctx: Context) => {
             return;
         }
 
-        // AI-generated images are public (no auth required)
+        if (name.startsWith('recipe-image/')) {
+            // AI-generated recipe images: public, bucket only — no fallback generation
+            const bucketStore = getBucketStore();
+            try {
+                const head = await bucketStore.getHeadObject(name);
+                const contentType = head?.metaData?.['content-type'] ?? 'image/webp';
+                const stream = await bucketStore.getObjectStream(name);
+
+                logger.info('API: Recipe AI image retrieved', { imageKey: name, contentType });
+
+                ctx.set('Content-Type', contentType);
+                ctx.set('Cache-Control', 'public, max-age=31536000, immutable');
+                ctx.status = 200;
+
+                await new Promise((resolve, reject) => {
+                    stream.pipe(ctx.res, { end: true });
+                    stream.on('end', resolve);
+                    stream.on('error', reject);
+                });
+            } catch {
+                ctx.status = 404;
+                ctx.body = { error: 'Image not found' };
+            }
+            return;
+        }
+
+        // Shopping list AI images: public, with AI generation fallback
         const { stream, contentType, cacheControl } = await getImageService().getImage(name);
 
         logger.info('API: AI image retrieved', {

--- a/packages/web/src/components/RecipeCard/index.test.tsx
+++ b/packages/web/src/components/RecipeCard/index.test.tsx
@@ -73,11 +73,10 @@ describe('RecipeCard', () => {
         });
     });
 
-    it('shows placeholder when no image', () => {
+    it('shows skeleton when no coverImageKey', () => {
         const { container } = render(<RecipeCard recipe={mockRecipeNoImage} onClick={vi.fn()} />);
 
-        // Should show cooking emoji placeholder
-        expect(container.textContent).toContain('🍳');
+        expect(container.querySelector('[data-slot="skeleton"]')).toBeTruthy();
     });
 
     it('calls onClick when card is clicked', () => {
@@ -118,15 +117,5 @@ describe('RecipeCard', () => {
         unmount();
 
         expect(global.URL.revokeObjectURL).toHaveBeenCalled();
-    });
-
-    it('shows pizza spinner when isGeneratingImage is true and no image loaded', () => {
-        render(<RecipeCard recipe={mockRecipeNoImage} onClick={vi.fn()} isGeneratingImage />);
-        expect(screen.getByLabelText('Generating recipe image')).toBeTruthy();
-    });
-
-    it('does not show pizza spinner when isGeneratingImage is false', () => {
-        render(<RecipeCard recipe={mockRecipeNoImage} onClick={vi.fn()} isGeneratingImage={false} />);
-        expect(screen.queryByLabelText('Generating recipe image')).toBeNull();
     });
 });

--- a/packages/web/src/components/RecipeCard/index.tsx
+++ b/packages/web/src/components/RecipeCard/index.tsx
@@ -9,10 +9,9 @@ import { getAuthConfig } from '../../config/auth';
 interface RecipeCardProps {
     recipe: Recipe;
     onClick: () => void;
-    isGeneratingImage?: boolean;
 }
 
-export const RecipeCard = ({ recipe, onClick, isGeneratingImage }: RecipeCardProps) => {
+export const RecipeCard = ({ recipe, onClick }: RecipeCardProps) => {
     const [imageUrl, setImageUrl] = useState<string | null>(null);
     const [isLoadingImage, setIsLoadingImage] = useState(() => !!recipe.coverImageKey);
     const [hasImageError, setHasImageError] = useState(false);
@@ -23,6 +22,8 @@ export const RecipeCard = ({ recipe, onClick, isGeneratingImage }: RecipeCardPro
             setIsLoadingImage(false);
             return;
         }
+
+        setIsLoadingImage(true);
 
         const fetchImage = async () => {
             try {
@@ -90,24 +91,9 @@ export const RecipeCard = ({ recipe, onClick, isGeneratingImage }: RecipeCardPro
                     />
                 )}
 
-                {isLoadingImage && !imageUrl && !hasImageError && (
+                {(isLoadingImage || !recipe.coverImageKey) && !imageUrl && !hasImageError && (
                     <Skeleton className="absolute inset-0 h-full w-full rounded-none" />
                 )}
-
-                {!recipe.coverImageKey &&
-                    !imageUrl &&
-                    !hasImageError &&
-                    (isGeneratingImage ? (
-                        <div
-                            role="img"
-                            aria-label="Generating recipe image"
-                            className="absolute inset-0 flex items-center justify-center text-4xl animate-pulse"
-                        >
-                            🍕
-                        </div>
-                    ) : (
-                        <div className="absolute inset-0 flex items-center justify-center text-4xl">🍳</div>
-                    ))}
 
                 {hasImageError && (
                     <div className="absolute inset-0 flex items-center justify-center bg-muted/20 text-muted-foreground">


### PR DESCRIPTION
## Summary
- **ImageHandlers**: `recipe-image/*` keys now served from bucket directly — the shopping-list `ImageService` (with its AI generation fallback) can no longer fire a second generation when a recipe image hasn't been stored yet. Priority: uploaded image (`recipe-upload/`) → AI-generated (`recipe-image/`) → 404
- **RecipeCard**: skeleton shows for all no-image states (waiting for generation and while fetching). `isLoadingImage` now resets correctly when `coverImageKey` changes, so the skeleton also appears during the transition after generation completes. Removed unused `isGeneratingImage` prop and emoji placeholders.

## Test plan
- [ ] 376 API tests pass
- [ ] 344 web tests pass
- [ ] Lint clean
- [ ] Create a recipe → skeleton shows immediately, then image appears once generated
- [ ] Only one AI call per unique title (second recipe with same title gets cached image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)