### PR TITLE
fix(api): share recipes with selected users at creation time

### DIFF
--- a/packages/api/src/dependencies/index.ts
+++ b/packages/api/src/dependencies/index.ts
@@ -75,7 +75,8 @@ export const registerDepdendencies = () => {
                     dependencyContainer.resolve(DependencyToken.IdGenerator),
                     dependencyContainer.resolve(DependencyToken.Logger),
                     dependencyContainer.resolve(DependencyToken.AuthorizationService),
-                    dependencyContainer.resolve(DependencyToken.RecipeImageService)
+                    dependencyContainer.resolve(DependencyToken.RecipeImageService),
+                    dependencyContainer.resolve(DependencyToken.AuthClient)
                 );
             }
         }

--- a/packages/api/src/domain/RecipeService/index.test.ts
+++ b/packages/api/src/domain/RecipeService/index.test.ts
@@ -70,9 +70,25 @@ const repo = new MockRepository();
 const ids = new MockIdGenerator();
 const owner: User = { id: 'user-1', username: 'alice' };
 
+const user2: User = { id: 'user-2', username: 'bob' };
+const user3: User = { id: 'user-3', username: 'carol' };
+
+class MockAuthClient {
+    users: User[] = [];
+    async getUsersByUsernames(usernames: string[]): Promise<User[]> {
+        return this.users.filter((u) => usernames.includes(u.username));
+    }
+    reset() {
+        this.users = [];
+    }
+}
+
+const mockAuth = new MockAuthClient();
+
 beforeEach(() => {
     repo.reset();
     ids.reset();
+    mockAuth.reset();
 });
 
 describe('RecipeService.createRecipe', () => {
@@ -91,6 +107,38 @@ describe('RecipeService.createRecipe', () => {
         const recipe = await svc.createRecipe('Pasta', [], owner.id, owner);
         expect(recipe.link).toBeUndefined();
         expect(recipe.instructions).toBeUndefined();
+    });
+
+    it('creates recipe with only owner when no selectedUsers provided', async () => {
+        const svc = new RecipeService(repo as any, ids, undefined, undefined, undefined, mockAuth as any);
+        const recipe = await svc.createRecipe('Pasta', [], owner.id, owner);
+        expect(recipe.users).toHaveLength(1);
+        expect(recipe.users[0].id).toBe(owner.id);
+    });
+
+    it('shares recipe with selected users at creation time', async () => {
+        mockAuth.users = [user2, user3];
+        const svc = new RecipeService(repo as any, ids, undefined, undefined, undefined, mockAuth as any);
+        const recipe = await svc.createRecipe('Pasta', [], owner.id, owner, undefined, undefined, ['bob', 'carol']);
+        expect(recipe.users).toHaveLength(3);
+        expect(recipe.users.map((u) => u.id)).toContain(owner.id);
+        expect(recipe.users.map((u) => u.id)).toContain(user2.id);
+        expect(recipe.users.map((u) => u.id)).toContain(user3.id);
+    });
+
+    it('throws 502 when selectedUsers provided but no auth service configured', async () => {
+        const svc = new RecipeService(repo as any, ids);
+        await expect(
+            svc.createRecipe('Pasta', [], owner.id, owner, undefined, undefined, ['bob'])
+        ).rejects.toMatchObject({ status: 502 });
+    });
+
+    it('throws 400 when selected usernames resolve to no users', async () => {
+        mockAuth.users = [];
+        const svc = new RecipeService(repo as any, ids, undefined, undefined, undefined, mockAuth as any);
+        await expect(
+            svc.createRecipe('Pasta', [], owner.id, owner, undefined, undefined, ['nonexistent'])
+        ).rejects.toMatchObject({ status: 400 });
     });
 });
 
@@ -227,8 +275,6 @@ describe('RecipeService.deleteRecipe', () => {
         await expect(svc.deleteRecipe('missing', owner.id)).rejects.toMatchObject({ status: 404 });
     });
 });
-
-const user2: User = { id: 'user-2', username: 'bob' };
 
 describe('RecipeService.addUserToRecipe', () => {
     it('adds user to recipe', async () => {

--- a/packages/api/src/domain/RecipeService/index.ts
+++ b/packages/api/src/domain/RecipeService/index.ts
@@ -4,6 +4,10 @@ import { AuthorizationService } from '../AuthorizationService';
 import type { RecipeImageService } from '../RecipeImageService';
 import type { RecipeRepository } from '../RecipeRepository';
 
+interface AuthClient {
+    getUsersByUsernames(usernames: Array<string>): Promise<Array<User>>;
+}
+
 export class RecipeService {
     private readonly authorizationService: AuthorizationService;
 
@@ -12,9 +16,72 @@ export class RecipeService {
         private idGenerator: IdGenerator,
         private logger?: Logger,
         authorizationService?: AuthorizationService,
-        private recipeImageService?: RecipeImageService
+        private recipeImageService?: RecipeImageService,
+        private auth?: AuthClient
     ) {
         this.authorizationService = authorizationService ?? new AuthorizationService();
+    }
+
+    private async resolveSharedUsers(title: string, owner: User, usernames?: Array<string>): Promise<Array<User>> {
+        if (!usernames || usernames.length === 0) {
+            return [owner];
+        }
+
+        if (!this.auth) {
+            throw Object.assign(new Error('Auth service not configured'), { status: 502 });
+        }
+
+        try {
+            const fetched = await this.auth.getUsersByUsernames(usernames);
+
+            if (!fetched || fetched.length === 0) {
+                throw Object.assign(new Error('No users found for the provided usernames'), {
+                    status: 400,
+                    usersNotFound: true,
+                });
+            }
+
+            this.logger?.info('Recipe shared with users', {
+                recipeTitle: title,
+                owner: owner.username,
+                sharedWithCount: fetched.length,
+                sharedWith: fetched.map((u) => u.username),
+            });
+
+            return [owner, ...fetched];
+        } catch (error) {
+            const errorWithStatus = error as {
+                status?: number;
+                usersNotFound?: boolean;
+                authServiceError?: boolean;
+            };
+
+            if (errorWithStatus.usersNotFound) {
+                this.logger?.warn('Attempted to share recipe with non-existent users', {
+                    recipeTitle: title,
+                    owner: owner.username,
+                    selectedUsernames: usernames,
+                    message: (error as Error).message,
+                });
+                throw error;
+            } else if (errorWithStatus.authServiceError) {
+                this.logger?.error('Auth service unavailable when sharing recipe', {
+                    recipeTitle: title,
+                    owner: owner.username,
+                    selectedUsernames: usernames,
+                    message: (error as Error).message,
+                });
+                throw Object.assign(new Error('Auth service unavailable. Please try again later.'), { status: 502 });
+            } else {
+                this.logger?.error('Failed to share recipe with users', {
+                    recipeTitle: title,
+                    owner: owner.username,
+                    selectedUsernames: usernames,
+                    error,
+                });
+                throw Object.assign(new Error('Failed to share recipe. Please try again.'), { status: 500 });
+            }
+        }
     }
 
     async createRecipe(
@@ -23,9 +90,11 @@ export class RecipeService {
         ownerId: string,
         owner: User,
         link?: string,
-        instructions?: string[]
+        instructions?: string[],
+        selectedUsers?: string[]
     ): Promise<Recipe> {
         try {
+            const users = await this.resolveSharedUsers(title, owner, selectedUsers);
             const recipe: Recipe = {
                 id: this.idGenerator.generate(),
                 title,
@@ -34,7 +103,7 @@ export class RecipeService {
                     id: this.idGenerator.generate(),
                 })),
                 ownerId,
-                users: [owner],
+                users,
                 dateAdded: new Date(),
                 ...(link !== undefined && { link }),
                 ...(instructions !== undefined && { instructions }),

--- a/packages/api/src/interfaces/RecipeHandlers/index.ts
+++ b/packages/api/src/interfaces/RecipeHandlers/index.ts
@@ -122,11 +122,12 @@ export const getRecipe = async (ctx: Context): Promise<void> => {
 };
 
 export const createRecipe = async (ctx: Context): Promise<void> => {
-    const { title, ingredients, link, instructions } = ctx.request.body as {
+    const { title, ingredients, link, instructions, selectedUsers } = ctx.request.body as {
         title: string;
         ingredients: Ingredient[];
         link?: string;
         instructions?: string[];
+        selectedUsers?: string[];
     };
     const logger = getLogger();
     const authenticatedUser = getAuthenticatedUser(ctx);
@@ -159,7 +160,8 @@ export const createRecipe = async (ctx: Context): Promise<void> => {
             authenticatedUser.id,
             authenticatedUser,
             link,
-            instructions
+            instructions,
+            selectedUsers
         );
 
         logger.info('API: Recipe created', {


### PR DESCRIPTION
RecipeService.createRecipe was ignoring selectedUsers from the request
body, so shared users were never added. Added resolveSharedUsers (same
pattern as ListService), wired AuthClient into RecipeService, and
updated the createRecipe handler to pass selectedUsers through.

https://claude.ai/code/session_012iVekzDQtNwZbNeYomzDJ3