### PR TITLE
fix(web): fix recipe card skeleton during image generation

### DIFF
--- a/packages/web/src/components/RecipeCard/index.tsx
+++ b/packages/web/src/components/RecipeCard/index.tsx
@@ -13,17 +13,11 @@ interface RecipeCardProps {
 
 export const RecipeCard = ({ recipe, onClick }: RecipeCardProps) => {
     const [imageUrl, setImageUrl] = useState<string | null>(null);
-    const [isLoadingImage, setIsLoadingImage] = useState(() => !!recipe.coverImageKey);
     const [hasImageError, setHasImageError] = useState(false);
     const objectUrlRef = useRef<string | null>(null);
 
     useEffect(() => {
-        if (!recipe.coverImageKey) {
-            setIsLoadingImage(false);
-            return;
-        }
-
-        setIsLoadingImage(true);
+        if (!recipe.coverImageKey) return;
 
         const fetchImage = async () => {
             try {
@@ -51,8 +45,6 @@ export const RecipeCard = ({ recipe, onClick }: RecipeCardProps) => {
                 setImageUrl(url);
             } catch {
                 setHasImageError(true);
-            } finally {
-                setIsLoadingImage(false);
             }
         };
 
@@ -91,9 +83,7 @@ export const RecipeCard = ({ recipe, onClick }: RecipeCardProps) => {
                     />
                 )}
 
-                {(isLoadingImage || !recipe.coverImageKey) && !imageUrl && !hasImageError && (
-                    <Skeleton className="absolute inset-0 h-full w-full rounded-none" />
-                )}
+                {!imageUrl && !hasImageError && <Skeleton className="absolute inset-0 h-full w-full rounded-none" />}
 
                 {hasImageError && (
                     <div className="absolute inset-0 flex items-center justify-center bg-muted/20 text-muted-foreground">


### PR DESCRIPTION
## Summary
- Fixes missing skeleton in recipe cards while waiting for AI-generated images to load
- Root cause: `isLoadingImage` was `false` during the render gap when `coverImageKey` first arrives (after image generation completes) but before the fetch effect runs
- Fix: replace the fragile `(isLoadingImage || !recipe.coverImageKey) && !imageUrl` condition with simply `!imageUrl` — skeleton shows whenever there's no loaded image URL, covering placeholder, loading, and the transition gap

## Test plan
- [ ] Create a new recipe and observe the card immediately shows a skeleton, which transitions to the AI-generated image once ready
- [ ] Existing recipes with images show skeleton briefly while the image fetches
- [ ] Recipes without images show the skeleton placeholder (muted background shimmer)
- [ ] All 344 web tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)