### PR TITLE
fix: show skeleton while AI recipe image is loading

### DIFF
--- a/packages/web/src/components/RecipeCard/index.tsx
+++ b/packages/web/src/components/RecipeCard/index.tsx
@@ -74,7 +74,7 @@ export const RecipeCard = ({ recipe, onClick }: RecipeCardProps) => {
                 }
             }}
         >
-            <div className="relative flex-1 w-full overflow-hidden bg-muted rounded-t-lg">
+            <div className="relative flex-1 w-full overflow-hidden bg-muted rounded-t-lg min-h-40">
                 {imageUrl && !hasImageError && (
                     <img
                         src={imageUrl}
@@ -83,7 +83,9 @@ export const RecipeCard = ({ recipe, onClick }: RecipeCardProps) => {
                     />
                 )}
 
-                {!imageUrl && !hasImageError && <Skeleton className="absolute inset-0 h-full w-full rounded-none" />}
+                {!imageUrl && !hasImageError && recipe.coverImageKey && (
+                    <Skeleton className="absolute inset-0 h-full w-full rounded-none" />
+                )}
 
                 {hasImageError && (
                     <div className="absolute inset-0 flex items-center justify-center bg-muted/20 text-muted-foreground">


### PR DESCRIPTION
The image container had no minimum height, so flex-1 collapsed to zero
when only the absolutely-positioned skeleton was present (no real image
yet). Also scoped the skeleton to only show when coverImageKey exists,
avoiding an infinite skeleton on recipes with no image.

https://claude.ai/code/session_01Q4gLyAa6eTHmpPfPpKTHvX