### PR TITLE
feat(web): add pull-to-refresh with haptics, overscroll indicator, and PWA update check

### DIFF
--- a/packages/web/src/components/Layout/index.test.tsx
+++ b/packages/web/src/components/Layout/index.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { PullToRefreshProvider } from '../../contexts/PullToRefreshContext';
 import { Layout } from './index';
+
+const renderWithProvider = (ui: React.ReactElement) => render(<PullToRefreshProvider>{ui}</PullToRefreshProvider>);
 
 describe('Layout', () => {
     it('renders children', () => {
-        render(
+        renderWithProvider(
             <Layout>
                 <p>Test content</p>
             </Layout>
@@ -14,7 +17,7 @@ describe('Layout', () => {
     });
 
     it('applies fixed positioning styles', () => {
-        const { container } = render(
+        const { container } = renderWithProvider(
             <Layout>
                 <p>Content</p>
             </Layout>
@@ -25,7 +28,7 @@ describe('Layout', () => {
     });
 
     it('applies padding and max-width', () => {
-        const { container } = render(
+        const { container } = renderWithProvider(
             <Layout>
                 <p>Content</p>
             </Layout>
@@ -36,14 +39,15 @@ describe('Layout', () => {
     });
 
     it('renders children in reverse flex column', () => {
-        const { container } = render(
+        const { container } = renderWithProvider(
             <Layout>
                 <p>Content</p>
             </Layout>
         );
 
         const outerDiv = container.firstChild as HTMLElement;
-        const innerDiv = outerDiv.firstChild as HTMLElement;
-        expect(innerDiv).toHaveClass('flex-col-reverse', 'overflow-y-auto', 'h-full');
+        // The scroll container is the last child (after PullToRefreshIndicator)
+        const scrollDiv = outerDiv.lastElementChild as HTMLElement;
+        expect(scrollDiv).toHaveClass('flex-col-reverse', 'overflow-y-auto', 'h-full', 'overscroll-y-contain');
     });
 });

--- a/packages/web/src/components/Layout/index.tsx
+++ b/packages/web/src/components/Layout/index.tsx
@@ -1,13 +1,22 @@
 import type { ReactNode } from 'react';
+import { usePullToRefreshContext } from '../../contexts/PullToRefreshContext';
+import { usePullToRefresh } from '../../hooks/usePullToRefresh';
+import { PullToRefreshIndicator } from '../PullToRefreshIndicator';
 
 interface LayoutProps {
     children: ReactNode;
 }
 
 export const Layout = ({ children }: LayoutProps) => {
+    const { executeRefresh } = usePullToRefreshContext();
+    const { scrollRef, pullY, isRefreshing, hasTriggered } = usePullToRefresh(executeRefresh);
+
     return (
         <div className="fixed top-16 bottom-24 left-0 right-0 px-4 py-2 max-w-[500px] mx-auto">
-            <div className="h-full overflow-y-auto flex flex-col-reverse">{children}</div>
+            <PullToRefreshIndicator pullY={pullY} isRefreshing={isRefreshing} hasTriggered={hasTriggered} />
+            <div ref={scrollRef} className="h-full overflow-y-auto flex flex-col-reverse overscroll-y-contain">
+                {children}
+            </div>
         </div>
     );
 };

--- a/packages/web/src/components/PullToRefreshIndicator/index.tsx
+++ b/packages/web/src/components/PullToRefreshIndicator/index.tsx
@@ -1,0 +1,37 @@
+import { Loader2, RefreshCw } from 'lucide-react';
+import { type MotionValue, motion, useTransform } from 'motion/react';
+
+interface PullToRefreshIndicatorProps {
+    pullY: MotionValue<number>;
+    isRefreshing: boolean;
+    hasTriggered: boolean;
+}
+
+const MAX_PULL = 120;
+const THRESHOLD = 80;
+
+export const PullToRefreshIndicator = ({ pullY, isRefreshing, hasTriggered }: PullToRefreshIndicatorProps) => {
+    const opacity = useTransform(pullY, [0, 40], [0, 1]);
+    const scale = useTransform(pullY, [0, MAX_PULL], [0.3, 1.0]);
+    const height = useTransform(pullY, [0, MAX_PULL], ['0px', '52px']);
+    const iconRotate = useTransform(pullY, [0, THRESHOLD * 1.5], [0, 180]);
+
+    return (
+        <motion.div style={{ height, opacity }} className="flex items-center justify-center overflow-hidden">
+            <motion.div
+                style={{ scale }}
+                className="flex items-center justify-center w-8 h-8 rounded-full bg-background border border-border shadow-sm"
+            >
+                {isRefreshing ? (
+                    <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                ) : (
+                    <motion.div style={{ rotate: iconRotate }}>
+                        <RefreshCw
+                            className={`h-4 w-4 transition-colors ${hasTriggered ? 'text-primary' : 'text-muted-foreground'}`}
+                        />
+                    </motion.div>
+                )}
+            </motion.div>
+        </motion.div>
+    );
+};

--- a/packages/web/src/contexts/PullToRefreshContext.tsx
+++ b/packages/web/src/contexts/PullToRefreshContext.tsx
@@ -1,0 +1,55 @@
+import { createContext, type ReactNode, useCallback, useContext, useRef } from 'react';
+
+type RefreshFn = () => Promise<void>;
+
+interface PullToRefreshContextType {
+    registerRefresh: (fn: RefreshFn) => () => void;
+    executeRefresh: () => Promise<void>;
+}
+
+const PullToRefreshContext = createContext<PullToRefreshContextType>({
+    registerRefresh: () => () => {},
+    executeRefresh: async () => {},
+});
+
+export const usePullToRefreshContext = () => useContext(PullToRefreshContext);
+
+interface PullToRefreshProviderProps {
+    children: ReactNode;
+}
+
+export const PullToRefreshProvider = ({ children }: PullToRefreshProviderProps) => {
+    const refreshFnRef = useRef<RefreshFn | null>(null);
+    const isExecutingRef = useRef(false);
+
+    const registerRefresh = useCallback((fn: RefreshFn) => {
+        refreshFnRef.current = fn;
+        return () => {
+            refreshFnRef.current = null;
+        };
+    }, []);
+
+    const executeRefresh = useCallback(async () => {
+        if (isExecutingRef.current) return;
+        isExecutingRef.current = true;
+        try {
+            await refreshFnRef.current?.();
+            if ('serviceWorker' in navigator) {
+                try {
+                    const registration = await navigator.serviceWorker.ready;
+                    await registration.update();
+                } catch {
+                    // Silent fail — SW may not be available in dev or tests
+                }
+            }
+        } finally {
+            isExecutingRef.current = false;
+        }
+    }, []);
+
+    return (
+        <PullToRefreshContext.Provider value={{ registerRefresh, executeRefresh }}>
+            {children}
+        </PullToRefreshContext.Provider>
+    );
+};

--- a/packages/web/src/hooks/usePullToRefresh.ts
+++ b/packages/web/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,116 @@
+import { animate, useMotionValue } from 'motion/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const RESISTANCE = 0.4;
+const THRESHOLD = 80;
+const MAX_PULL = 120;
+
+const SPRING_BACK = { type: 'spring', stiffness: 300, damping: 30 } as const;
+const SPRING_HOLD = { type: 'spring', stiffness: 200, damping: 25 } as const;
+
+export interface UsePullToRefreshReturn {
+    scrollRef: React.RefObject<HTMLDivElement | null>;
+    pullY: ReturnType<typeof useMotionValue<number>>;
+    isRefreshing: boolean;
+    hasTriggered: boolean;
+}
+
+export function usePullToRefresh(onRefresh: () => Promise<void>): UsePullToRefreshReturn {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [hasTriggered, setHasTriggered] = useState(false);
+
+    const pullY = useMotionValue(0);
+
+    const isPulling = useRef(false);
+    const touchStartY = useRef(0);
+    const hasFiredHaptic = useRef(false);
+    const isRefreshingRef = useRef(false);
+    const currentAnim = useRef<ReturnType<typeof animate> | null>(null);
+
+    const springTo = useCallback(
+        (target: number, config: typeof SPRING_BACK | typeof SPRING_HOLD) => {
+            currentAnim.current?.stop();
+            currentAnim.current = animate(pullY, target, config);
+        },
+        [pullY]
+    );
+
+    useEffect(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+
+        const onTouchStart = (e: TouchEvent) => {
+            if (isRefreshingRef.current) return;
+            if (el.scrollTop > 0) return;
+            touchStartY.current = e.touches[0].clientY;
+            isPulling.current = true;
+            hasFiredHaptic.current = false;
+        };
+
+        const onTouchMove = (e: TouchEvent) => {
+            if (!isPulling.current) return;
+            if (el.scrollTop > 0) {
+                isPulling.current = false;
+                return;
+            }
+
+            const rawDelta = e.touches[0].clientY - touchStartY.current;
+            if (rawDelta <= 0) {
+                isPulling.current = false;
+                pullY.set(0);
+                return;
+            }
+
+            e.preventDefault();
+
+            const resisted = Math.min(rawDelta * RESISTANCE, MAX_PULL);
+            pullY.set(resisted);
+
+            if (resisted >= THRESHOLD && !hasFiredHaptic.current) {
+                hasFiredHaptic.current = true;
+                navigator.vibrate?.(10);
+                setHasTriggered(true);
+            } else if (resisted < THRESHOLD && hasFiredHaptic.current) {
+                hasFiredHaptic.current = false;
+                setHasTriggered(false);
+            }
+        };
+
+        const onTouchEnd = async () => {
+            if (!isPulling.current) return;
+            isPulling.current = false;
+
+            const current = pullY.get();
+            if (current >= THRESHOLD) {
+                springTo(THRESHOLD, SPRING_HOLD);
+                isRefreshingRef.current = true;
+                setIsRefreshing(true);
+                try {
+                    await onRefresh();
+                } finally {
+                    isRefreshingRef.current = false;
+                    setIsRefreshing(false);
+                    setHasTriggered(false);
+                    springTo(0, SPRING_BACK);
+                }
+            } else {
+                setHasTriggered(false);
+                springTo(0, SPRING_BACK);
+            }
+        };
+
+        el.addEventListener('touchstart', onTouchStart, { passive: true });
+        el.addEventListener('touchmove', onTouchMove, { passive: false });
+        el.addEventListener('touchend', onTouchEnd, { passive: true });
+
+        return () => {
+            el.removeEventListener('touchstart', onTouchStart);
+            el.removeEventListener('touchmove', onTouchMove);
+            el.removeEventListener('touchend', onTouchEnd);
+            currentAnim.current?.stop();
+        };
+    }, [onRefresh, pullY, springTo]);
+
+    return { scrollRef, pullY, isRefreshing, hasTriggered };
+}

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -13,6 +13,7 @@ import LoadingPage from './components/LoadingPage';
 import { RootLayout } from './components/RootLayout';
 import RouterErrorHandler from './components/RouterErrorHandler';
 import { getAuthConfig } from './config/auth';
+import { PullToRefreshProvider } from './contexts/PullToRefreshContext';
 import { PWAProvider } from './contexts/PWAContext';
 import { ThemeProvider } from './contexts/ThemeContext';
 
@@ -135,9 +136,11 @@ const AppContent: React.FC = () => {
                 <UserProvider>
                     <AuthProvider>
                         <ThemeProvider>
-                            <PWAProvider>
-                                <RouterProvider router={router} />
-                            </PWAProvider>
+                            <PullToRefreshProvider>
+                                <PWAProvider>
+                                    <RouterProvider router={router} />
+                                </PWAProvider>
+                            </PullToRefreshProvider>
                         </ThemeProvider>
                     </AuthProvider>
                 </UserProvider>

--- a/packages/web/src/pages/ItemsPage/index.tsx
+++ b/packages/web/src/pages/ItemsPage/index.tsx
@@ -17,6 +17,7 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from '../../components/ui/alert-dialog';
+import { usePullToRefreshContext } from '../../contexts/PullToRefreshContext';
 import { useConfirmation } from '../../hooks/useConfirmation';
 import { useItemPageMutations } from '../../hooks/useItemPageMutations';
 import { logger } from '../../utils/logger';
@@ -40,6 +41,13 @@ const ItemsPage = () => {
     const selectedItemsCount = items.filter((item) => item.isSelected).length;
 
     const { addItemMutation, clearSelectedMutation, clearListMutation } = useItemPageMutations(listTitle);
+    const { registerRefresh } = usePullToRefreshContext();
+
+    useEffect(() => {
+        return registerRefresh(async () => {
+            await refetch();
+        });
+    }, [registerRefresh, refetch]);
 
     useEffect(() => {
         setCurrentListType(listType);

--- a/packages/web/src/pages/ListsPage/index.tsx
+++ b/packages/web/src/pages/ListsPage/index.tsx
@@ -9,6 +9,7 @@ import { ListsSkeleton } from '../../components/LoadingSkeleton';
 import ToolBar from '../../components/ToolBar';
 import { Button } from '../../components/ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../../components/ui/empty';
+import { usePullToRefreshContext } from '../../contexts/PullToRefreshContext';
 import { logger } from '../../utils/logger';
 
 const ListsPage = () => {
@@ -17,6 +18,13 @@ const ListsPage = () => {
         ...getListsQuery(user?.id || ''),
         enabled: !!user?.id,
     });
+    const { registerRefresh } = usePullToRefreshContext();
+
+    useEffect(() => {
+        return registerRefresh(async () => {
+            await refetch();
+        });
+    }, [registerRefresh, refetch]);
 
     useEffect(() => {
         if (user?.id) {

--- a/packages/web/src/pages/RecipesPage/index.tsx
+++ b/packages/web/src/pages/RecipesPage/index.tsx
@@ -10,6 +10,7 @@ import ToolBar from '../../components/ToolBar';
 import { Button } from '../../components/ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../../components/ui/empty';
 import { Input } from '../../components/ui/input';
+import { usePullToRefreshContext } from '../../contexts/PullToRefreshContext';
 import { useRecipeSearch } from '../../hooks/useRecipeSearch';
 import { logger } from '../../utils/logger';
 
@@ -26,6 +27,13 @@ const RecipesPage = () => {
         ...getRecipesQuery(user?.id || ''),
         enabled: !!user?.id,
     });
+    const { registerRefresh } = usePullToRefreshContext();
+
+    useEffect(() => {
+        return registerRefresh(async () => {
+            await refetch();
+        });
+    }, [registerRefresh, refetch]);
 
     useEffect(() => {
         if (user?.id) {

--- a/packages/web/src/test-setup.ts
+++ b/packages/web/src/test-setup.ts
@@ -25,6 +25,12 @@ if (typeof URL !== 'undefined') {
     URL.revokeObjectURL = vi.fn();
 }
 
+// Mock navigator.vibrate (not supported in jsdom)
+Object.defineProperty(navigator, 'vibrate', {
+    writable: true,
+    value: vi.fn(),
+});
+
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {
     writable: true,


### PR DESCRIPTION
Implements a native-feeling pull-to-refresh gesture on all main pages
(ListsPage, ItemsPage, RecipesPage) that re-fetches page data, shows a
spring-animated overscroll indicator, fires haptic feedback at the pull
threshold, and triggers a service worker update check on each refresh so
users are promptly notified of new PWA versions.

https://claude.ai/code/session_017g1HyeELhh2SZVVyrm3mmU