### PR TITLE
fix(web): pull-to-refresh scroll fix and indicator polish

### DIFF
--- a/packages/web/src/components/PullToRefreshIndicator/index.tsx
+++ b/packages/web/src/components/PullToRefreshIndicator/index.tsx
@@ -17,17 +17,17 @@ export const PullToRefreshIndicator = ({ pullY, isRefreshing, hasTriggered }: Pu
     const iconRotate = useTransform(pullY, [0, THRESHOLD * 1.5], [0, 180]);
 
     return (
-        <motion.div style={{ height, opacity }} className="flex items-center justify-center overflow-hidden">
+        <motion.div style={{ height, opacity }} className="flex items-end justify-center overflow-hidden pb-1">
             <motion.div
                 style={{ scale }}
-                className="flex items-center justify-center w-8 h-8 rounded-full bg-background border border-border shadow-sm"
+                className="flex items-center justify-center w-12 h-12 rounded-full bg-background border border-border shadow-sm"
             >
                 {isRefreshing ? (
-                    <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                    <Loader2 className="h-6 w-6 animate-spin text-primary" />
                 ) : (
                     <motion.div style={{ rotate: iconRotate }}>
                         <RefreshCw
-                            className={`h-4 w-4 transition-colors ${hasTriggered ? 'text-primary' : 'text-muted-foreground'}`}
+                            className={`h-6 w-6 transition-colors ${hasTriggered ? 'text-primary' : 'text-muted-foreground'}`}
                         />
                     </motion.div>
                 )}

--- a/packages/web/src/hooks/usePullToRefresh.ts
+++ b/packages/web/src/hooks/usePullToRefresh.ts
@@ -4,6 +4,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 const RESISTANCE = 0.4;
 const THRESHOLD = 80;
 const MAX_PULL = 120;
+// Minimum downward travel before committing to pull mode and calling preventDefault.
+// Without this, any tiny downward jitter at scrollTop=0 would lock the touch sequence
+// into pull mode and prevent the browser from scrolling.
+const PULL_COMMIT_THRESHOLD = 12;
 
 const SPRING_BACK = { type: 'spring', stiffness: 300, damping: 30 } as const;
 const SPRING_HOLD = { type: 'spring', stiffness: 200, damping: 25 } as const;
@@ -23,6 +27,7 @@ export function usePullToRefresh(onRefresh: () => Promise<void>): UsePullToRefre
     const pullY = useMotionValue(0);
 
     const isPulling = useRef(false);
+    const isCommitted = useRef(false); // true once we've called preventDefault and taken over the gesture
     const touchStartY = useRef(0);
     const hasFiredHaptic = useRef(false);
     const isRefreshingRef = useRef(false);
@@ -45,23 +50,37 @@ export function usePullToRefresh(onRefresh: () => Promise<void>): UsePullToRefre
             if (el.scrollTop > 0) return;
             touchStartY.current = e.touches[0].clientY;
             isPulling.current = true;
+            isCommitted.current = false;
             hasFiredHaptic.current = false;
         };
 
         const onTouchMove = (e: TouchEvent) => {
             if (!isPulling.current) return;
+            // User scrolled away from top — abort pull mode
             if (el.scrollTop > 0) {
                 isPulling.current = false;
+                isCommitted.current = false;
                 return;
             }
 
             const rawDelta = e.touches[0].clientY - touchStartY.current;
+
+            // Upward motion — let the browser scroll, stop tracking
             if (rawDelta <= 0) {
                 isPulling.current = false;
+                isCommitted.current = false;
                 pullY.set(0);
                 return;
             }
 
+            // Wait for enough downward movement before committing.
+            // During this window we don't call preventDefault, so if the user's
+            // intent turns out to be scrolling (rawDelta goes negative), the browser
+            // handles it naturally without us having blocked it first.
+            if (rawDelta < PULL_COMMIT_THRESHOLD) return;
+
+            // Clear downward intent confirmed — take over the gesture
+            isCommitted.current = true;
             e.preventDefault();
 
             const resisted = Math.min(rawDelta * RESISTANCE, MAX_PULL);
@@ -80,6 +99,13 @@ export function usePullToRefresh(onRefresh: () => Promise<void>): UsePullToRefre
         const onTouchEnd = async () => {
             if (!isPulling.current) return;
             isPulling.current = false;
+
+            // If we never committed (user didn't clearly pull down), do nothing
+            if (!isCommitted.current) {
+                isCommitted.current = false;
+                return;
+            }
+            isCommitted.current = false;
 
             const current = pullY.get();
             if (current >= THRESHOLD) {


### PR DESCRIPTION
## Summary

- Fix pull-to-refresh intercepting scroll gestures by adding a 12px commit threshold before calling `preventDefault` — prevents tiny downward jitter at `scrollTop=0` from locking the touch sequence and blocking normal scrolling
- Increase pull-to-refresh indicator badge from 32px to 48px circle with 24px icons
- Move indicator badge to the bottom of its animated area so it sits closer to the content edge

## Test plan

- [ ] Pull down from the top of Lists, Items, and Recipes pages — indicator appears and refresh triggers correctly
- [ ] Normal scrolling works on all pages without being intercepted
- [ ] Indicator badge is visibly larger and positioned lower (near content, not centred in the pull area)
- [ ] Haptic fires once at pull threshold; spinner shows during refetch

https://claude.ai/code/session_017g1HyeELhh2SZVVyrm3mmU

---
_Generated by [Claude Code](https://claude.ai/code/session_017g1HyeELhh2SZVVyrm3mmU)_