### PR TITLE
fix: store user-uploaded recipe image instead of generating AI image

### DIFF
--- a/packages/web/src/components/ToolBar/AddRecipeDrawer/index.tsx
+++ b/packages/web/src/components/ToolBar/AddRecipeDrawer/index.tsx
@@ -1,7 +1,6 @@
 import { ChefHat, Image as ImageIcon, Plus, X } from 'lucide-react';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { uploadRecipeImage } from '../../../api';
 import { SearchResults } from '../../../components/SearchResults';
 import { useSearch } from '../../../hooks/useSearch';
 import { Badge } from '../../ui/badge';
@@ -38,13 +37,11 @@ export interface AddRecipeDrawerProps {
         imageKey?: string,
         selectedUsers?: string[],
         link?: string,
-        instructions?: string[]
+        instructions?: string[],
+        imageFile?: File
     ) => Promise<Recipe | undefined>;
     placeholder?: string;
     initialLink?: string;
-    onRefetch?: () => void;
-    onImageGenerating?: (recipeId: string) => void;
-    onImageReady?: () => void;
 }
 
 const splitIntoSteps = (text: string): string[] =>
@@ -58,9 +55,6 @@ export const AddRecipeDrawer = ({
     onOpenChange,
     onAdd,
     initialLink,
-    onRefetch,
-    onImageGenerating,
-    onImageReady,
 }: AddRecipeDrawerProps) => {
     const recipeNameId = useId();
     const userSearchId = useId();
@@ -128,33 +122,14 @@ export const AddRecipeDrawer = ({
                 undefined,
                 selectedUsers,
                 link.trim() || undefined,
-                steps.length > 0 ? steps : undefined
+                steps.length > 0 ? steps : undefined,
+                selectedFile || undefined
             );
             if (!recipe) {
                 throw new Error('Failed to create recipe');
             }
 
-            const capturedFile = selectedFile;
-            const capturedTitle = title;
-            const capturedRecipeId = recipe.id;
-
             handleCancel();
-
-            if (capturedFile) {
-                void uploadRecipeImage(capturedRecipeId, capturedFile)
-                    .then(() => onRefetch?.())
-                    .catch(() => {});
-            } else {
-                onImageGenerating?.(capturedRecipeId);
-                void fetch(`/api/image/${encodeURIComponent(capturedTitle)}`, { method: 'GET' })
-                    .then((response) => {
-                        if (response.ok) {
-                            onRefetch?.();
-                            onImageReady?.();
-                        }
-                    })
-                    .catch(() => {});
-            }
         } catch (err) {
             const message = err instanceof Error ? err.message : 'Failed to create recipe';
             toast.error(message, { style: { backgroundColor: '#ef4444', color: '#ffffff' } });

--- a/packages/web/src/components/ToolBar/index.tsx
+++ b/packages/web/src/components/ToolBar/index.tsx
@@ -29,7 +29,8 @@ interface ToolBarProps {
         imageKey?: string,
         selectedUsers?: string[],
         link?: string,
-        instructions?: string[]
+        instructions?: string[],
+        imageFile?: File
     ) => Promise<Recipe | undefined>;
     addRecipeDrawerOpen?: boolean;
     onAddRecipeDrawerOpenChange?: (open: boolean) => void;

--- a/packages/web/src/pages/RecipesPage/index.tsx
+++ b/packages/web/src/pages/RecipesPage/index.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, BookOpen, ChefHat, Search, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { addRecipe, generateRecipeAiImage, getRecipesQuery } from '../../api';
+import { addRecipe, generateRecipeAiImage, getRecipesQuery, uploadRecipeImage } from '../../api';
 import { ListsSkeleton } from '../../components/LoadingSkeleton';
 import { RecipesList } from '../../components/RecipesList';
 import ToolBar from '../../components/ToolBar';
@@ -96,7 +96,8 @@ const RecipesPage = () => {
         _imageKey?: string,
         selectedUsers?: string[],
         link?: string,
-        instructions?: string[]
+        instructions?: string[],
+        imageFile?: File
     ) => {
         if (!user) {
             logger.warn('Attempted to add recipe without user');
@@ -106,10 +107,21 @@ const RecipesPage = () => {
         try {
             const recipe = await addRecipe(title, user, selectedUsers || [], ingredients, link, instructions);
             logger.info('Recipe created successfully', { title, recipeId: recipe.id });
+
+            if (imageFile) {
+                await uploadRecipeImage(recipe.id, imageFile);
+            } else {
+                generatingRef.current.add(recipe.id);
+            }
+
             await refetch();
-            void generateRecipeAiImage(recipe.id).then(() =>
-                queryClient.invalidateQueries(getRecipesQuery(user.id).queryKey)
-            );
+
+            if (!imageFile) {
+                void generateRecipeAiImage(recipe.id).then(() =>
+                    queryClient.invalidateQueries(getRecipesQuery(user.id).queryKey)
+                );
+            }
+
             return recipe;
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
When a user uploads an image during recipe creation, upload it before
refetching so the coverImageKey is already set when data refreshes.
Pre-populate generatingRef to prevent the useEffect from racing with
AI generation. AI generation is only triggered when no file is provided.

https://claude.ai/code/session_01FDPSwQzFfFo7sWD22CJARx