### PR TITLE
feat(e2e): Playwright E2E testing infrastructure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,8 +3,6 @@ name: CI/CD
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   lint:
@@ -119,7 +117,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, e2e]
-    if: github.event_name == 'push'
     permissions:
       contents: write
       packages: read

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,6 +3,8 @@ name: CI/CD
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   lint:
@@ -117,6 +119,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, e2e]
+    if: github.event_name == 'push'
     permissions:
       contents: write
       packages: read

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,9 +91,32 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: semgrep
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   release:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, e2e]
     permissions:
       contents: write
       packages: read

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,9 +47,32 @@ jobs:
           fi
           echo "✅ Coverage ${COVERAGE}% meets 90% threshold"
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   semgrep:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, e2e]
     permissions:
       contents: read
       security-events: write

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ coverage/
 
 # Playwright MCP artifacts
 .playwright-mcp/
+
+# Playwright E2E
+playwright-report/
+test-results/
+.auth/

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@commitlint/config-conventional": "^20.0.0",
         "@happy-dom/global-registrator": "^20.8.4",
         "@imapps/biome-config": "0.5.1",
+        "@playwright/test": "^1.60.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/exec": "^7.1.0",
@@ -28,7 +29,7 @@
     },
     "packages/api": {
       "name": "@shoppingo/api",
-      "version": "1.29.0",
+      "version": "1.32.3",
       "dependencies": {
         "@google/genai": "^1.16.0",
         "@imapps/api-utils": "0.5.1",
@@ -52,14 +53,14 @@
     },
     "packages/types": {
       "name": "@shoppingo/types",
-      "version": "1.29.0",
+      "version": "1.32.3",
       "dependencies": {
         "mongodb": "^6.19.0",
       },
     },
     "packages/web": {
       "name": "@shoppingo/web",
-      "version": "1.29.0",
+      "version": "1.32.3",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@imapps/web-utils": "0.5.1",
@@ -582,6 +583,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
+
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -1919,6 +1922,10 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
@@ -3012,6 +3019,8 @@
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/e2e/mocks/api.ts
+++ b/e2e/mocks/api.ts
@@ -1,0 +1,22 @@
+import type { Page } from '@playwright/test';
+
+export async function mockApiRoutes(page: Page) {
+    await page.route(/^http:\/\/localhost:4000\/api\//, (route) => {
+        const url = new URL(route.request().url());
+        const method = route.request().method();
+
+        if (url.pathname.match(/^\/api\/lists\/user\//) && method === 'GET') {
+            return route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify([]),
+            });
+        }
+
+        return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({}),
+        });
+    });
+}

--- a/e2e/mocks/auth.ts
+++ b/e2e/mocks/auth.ts
@@ -1,0 +1,38 @@
+import type { Page } from '@playwright/test';
+
+const makePart = (obj: object | string) =>
+    Buffer.from(typeof obj === 'string' ? obj : JSON.stringify(obj)).toString('base64');
+
+export const MOCK_TOKEN = [
+    makePart({ alg: 'HS256', typ: 'JWT' }),
+    makePart({ username: 'testuser', id: 'user-testuser', exp: 9999999999, iat: 1700000000 }),
+    makePart('mock-signature'),
+].join('.');
+
+export const MOCK_USER = { username: 'testuser', id: 'user-testuser' };
+
+export async function mockAuthRoutes(page: Page) {
+    await page.route('http://localhost:3008/login', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ token: MOCK_TOKEN, user: MOCK_USER }),
+        })
+    );
+
+    await page.route('http://localhost:3008/refresh', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ accessToken: MOCK_TOKEN }),
+        })
+    );
+
+    await page.route('http://localhost:3008/logout', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ message: 'Logout successful' }),
+        })
+    );
+}

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+import { mockApiRoutes } from '../mocks/api';
+import { mockAuthRoutes } from '../mocks/auth';
+
+test('login navigates to homepage', async ({ page }) => {
+    await mockAuthRoutes(page);
+    await mockApiRoutes(page);
+
+    await page.goto('/login');
+    await expect(page.getByText('Login to your account', { exact: true })).toBeVisible();
+
+    await page.getByLabel('Username').fill('testuser');
+    await page.getByLabel('Password').fill('password123');
+    await page.getByRole('button', { name: 'Login' }).click();
+
+    await page.waitForURL('/');
+    await expect(page.getByRole('heading', { name: 'Your Lists', level: 2 })).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "start:with-mock": "bun run start:web:with-mock & bun run start:api",
     "lint": "biome check .",
     "lint:fix": "biome check --fix --unsafe .",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "workspaces": [
     "packages/*"
@@ -23,6 +25,7 @@
     "@commitlint/config-conventional": "^20.0.0",
     "@happy-dom/global-registrator": "^20.8.4",
     "@imapps/biome-config": "0.5.1",
+    "@playwright/test": "^1.60.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/exec": "^7.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e/tests',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    reporter: 'html',
+    use: {
+        baseURL: 'http://localhost:4000',
+        trace: 'on-first-retry',
+        serviceWorkers: 'block',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+    webServer: {
+        command: 'bun run start:web',
+        url: 'http://localhost:4000',
+        reuseExistingServer: !process.env.CI,
+    },
+});


### PR DESCRIPTION
## Summary

- Installs `@playwright/test` with `serviceWorkers: 'block'` to allow `page.route()` to intercept API calls (Vite PWA service worker with `NetworkFirst` was intercepting `/api/*` before Playwright could)
- Auth mocked via `page.route()` against `localhost:3008` (login/refresh/logout) — no mock server process needed
- API mocked via anchored regex `^http://localhost:4000/api/` — avoids accidentally matching Vite's `/src/api/` source file paths
- Login E2E test: navigates to `/login`, fills credentials, asserts `Your Lists` heading is visible after redirect

## Test plan

- [ ] `bun run test:e2e` passes locally
- [ ] CI `e2e` job runs in parallel with `test`, both gate `release`
- [ ] Playwright report artifact uploads on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)