### PR TITLE
feat(e2e): add coverage for TODO lists, add-from-recipe, share-target, share-on-create

### DIFF
--- a/e2e/api-helpers.ts
+++ b/e2e/api-helpers.ts
@@ -20,7 +20,7 @@ export async function apiCreateList(title: string, listType = 'shopping') {
 export async function apiAddItem(
     listTitle: string,
     itemName: string,
-    overrides: { quantity?: number; unit?: string; isSelected?: boolean } = {}
+    overrides: { quantity?: number; unit?: string; isSelected?: boolean; dueDate?: string } = {}
 ) {
     const res = await fetch(`${API_BASE}/api/lists/${encodeURIComponent(listTitle)}/items`, {
         method: 'PUT',

--- a/e2e/page-objects/ItemsPage.ts
+++ b/e2e/page-objects/ItemsPage.ts
@@ -92,4 +92,34 @@ export class ItemsPage {
         await this.clearSelectedButton.click();
         await this.page.getByRole('button', { name: 'Clear Selected' }).click();
     }
+
+    // TODO list
+    get addTaskDrawerTitle() {
+        return this.page.getByText('Add New Task', { exact: true });
+    }
+
+    get taskNameInput() {
+        return this.page.getByLabel('Task Name');
+    }
+
+    get dueDateButton() {
+        return this.page.getByRole('button', { name: 'Pick a date' });
+    }
+
+    get dueDateOptionalLabel() {
+        return this.page.getByText('Due Date (Optional)');
+    }
+
+    // AddFromRecipe drawer
+    async openAddFromRecipeDrawer() {
+        await this.page.getByRole('button', { name: 'Add from recipe' }).click();
+    }
+
+    async chooseRecipe(title: string) {
+        await this.page.getByRole('button', { name: new RegExp(title) }).click();
+    }
+
+    async confirmAddFromRecipe() {
+        await this.page.getByRole('button', { name: /Add \d+ items/ }).click();
+    }
 }

--- a/e2e/tests/add-from-recipe.spec.ts
+++ b/e2e/tests/add-from-recipe.spec.ts
@@ -1,0 +1,96 @@
+import { apiAddItem, apiCreateList, apiCreateRecipe } from '../api-helpers';
+import { expect, test } from '../fixtures';
+
+const LIST_TITLE = 'Groceries';
+
+test.describe('Add From Recipe drawer (items page)', () => {
+    test('book icon opens "Choose Recipe" drawer', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE);
+        await apiCreateRecipe('Pasta');
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.getByRole('button', { name: 'Add from recipe' }).click();
+        await expect(authenticatedPage.getByText('Choose Recipe', { exact: true })).toBeVisible();
+    });
+
+    test('can search recipes in drawer', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE);
+        await apiCreateRecipe('Pasta Bolognese');
+        await apiCreateRecipe('Caesar Salad');
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.getByRole('button', { name: 'Add from recipe' }).click();
+        await authenticatedPage.getByPlaceholder('Search recipes...').fill('pasta');
+
+        await expect(authenticatedPage.getByText('Pasta Bolognese')).toBeVisible();
+        await expect(authenticatedPage.getByText('Caesar Salad')).not.toBeVisible();
+    });
+
+    test('selecting a recipe shows its ingredients', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE);
+        await apiCreateRecipe('My Soup', [{ name: 'Carrots' }, { name: 'Onion' }]);
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.getByRole('button', { name: 'Add from recipe' }).click();
+        await authenticatedPage.getByText('My Soup').click();
+
+        await expect(authenticatedPage.getByText('Select from My Soup')).toBeVisible();
+        await expect(authenticatedPage.getByText('Carrots')).toBeVisible();
+        await expect(authenticatedPage.getByText('Onion')).toBeVisible();
+    });
+
+    test('can add selected ingredients to list', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE);
+        await apiCreateRecipe('My Soup', [{ name: 'Carrots' }, { name: 'Onion' }, { name: 'Celery' }]);
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.getByRole('button', { name: 'Add from recipe' }).click();
+        await authenticatedPage.getByText('My Soup').click();
+
+        await authenticatedPage.getByText('Carrots').click();
+        await authenticatedPage.getByText('Onion').click();
+
+        await authenticatedPage.getByRole('button', { name: /Add 2 items/ }).click();
+
+        await expect(authenticatedPage.getByText('Carrots')).toBeVisible();
+        await expect(authenticatedPage.getByText('Onion')).toBeVisible();
+    });
+
+    test('already-in-list items show "Already in list" label', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE);
+        await apiAddItem(LIST_TITLE, 'Carrots');
+        await apiCreateRecipe('My Soup', [{ name: 'Carrots' }, { name: 'Onion' }]);
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.getByRole('button', { name: 'Add from recipe' }).click();
+        await authenticatedPage.getByText('My Soup').click();
+
+        await expect(authenticatedPage.getByText('Already in list')).toBeVisible();
+        await expect(authenticatedPage.getByText('Onion')).toBeVisible();
+    });
+
+    test('back button returns to recipe list', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE);
+        await apiCreateRecipe('My Soup', [{ name: 'Carrots' }]);
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.getByRole('button', { name: 'Add from recipe' }).click();
+        await authenticatedPage.getByText('My Soup').click();
+        await expect(authenticatedPage.getByText('Select from My Soup')).toBeVisible();
+
+        await authenticatedPage.getByRole('button', { name: 'Back to recipes' }).click();
+        await expect(authenticatedPage.getByText('Choose Recipe', { exact: true })).toBeVisible();
+    });
+
+    test('cancel closes the drawer', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE);
+        await apiCreateRecipe('My Soup', [{ name: 'Carrots' }]);
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.getByRole('button', { name: 'Add from recipe' }).click();
+        await authenticatedPage.getByText('My Soup').click();
+
+        await authenticatedPage.getByRole('button', { name: 'Cancel' }).click();
+        await expect(authenticatedPage.getByText('Choose Recipe')).not.toBeVisible();
+    });
+});

--- a/e2e/tests/share-target.spec.ts
+++ b/e2e/tests/share-target.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '../fixtures';
+
+test.describe('PWA Web Share Target', () => {
+    test('redirects to /recipes', async ({ authenticatedPage }) => {
+        await authenticatedPage.goto('/share?url=https://example.com/recipe&title=Test+Recipe');
+        await authenticatedPage.waitForURL(/\/recipes/, { timeout: 5000 });
+        await expect(authenticatedPage).toHaveURL(/\/recipes/);
+    });
+
+    test('opens "Create Recipe" drawer with pre-filled URL', async ({ authenticatedPage }) => {
+        await authenticatedPage.goto('/share?url=https://example.com/recipe&title=Test+Recipe');
+        await authenticatedPage.waitForURL(/\/recipes/, { timeout: 5000 });
+
+        // RecipesPage auto-opens AddRecipeDrawer when sharedUrl param is present
+        await expect(authenticatedPage.getByRole('heading', { name: 'Create Recipe' })).toBeVisible({ timeout: 5000 });
+
+        // Link field pre-filled with shared URL
+        await expect(authenticatedPage.getByPlaceholder('https://...')).toHaveValue('https://example.com/recipe');
+    });
+
+    test('share-target without url still redirects to /recipes', async ({ authenticatedPage }) => {
+        await authenticatedPage.goto('/share?title=Test+Recipe');
+        await authenticatedPage.waitForURL(/\/recipes/, { timeout: 5000 });
+        await expect(authenticatedPage).toHaveURL(/\/recipes/);
+
+        // Drawer should NOT auto-open when no sharedUrl
+        await expect(authenticatedPage.getByRole('heading', { name: 'Create Recipe' })).not.toBeVisible();
+    });
+});

--- a/e2e/tests/sharing.spec.ts
+++ b/e2e/tests/sharing.spec.ts
@@ -5,6 +5,37 @@ const waitForListData = async (page: import('@playwright/test').Page) => {
     await page.getByRole('button', { name: 'Menu' }).waitFor({ timeout: 10000 });
 };
 
+test.describe('Share list on creation', () => {
+    test('can share a list with a user during creation', async ({ authenticatedPage }) => {
+        await authenticatedPage.goto('/');
+        await expect(authenticatedPage.getByRole('heading', { name: 'Your Lists', level: 2 })).toBeVisible();
+
+        // Open add list dialog
+        await authenticatedPage.locator('button[class*="border-primary"]').first().click();
+        await expect(authenticatedPage.getByText('Add New List', { exact: true })).toBeVisible();
+
+        await authenticatedPage.getByLabel('List Name').fill('TeamList');
+
+        // Search for user to share with
+        await authenticatedPage.getByPlaceholder('Search users...').fill('other');
+        await expect(authenticatedPage.getByRole('button', { name: 'otheruser' })).toBeVisible();
+        await authenticatedPage.getByRole('button', { name: 'otheruser' }).click();
+
+        await authenticatedPage.getByRole('button', { name: 'Add List' }).click();
+        await expect(authenticatedPage.getByRole('button', { name: 'TeamList' })).toBeVisible();
+
+        // Navigate fresh to ensure list data (users) is fully loaded before checking members
+        await authenticatedPage.goto('/list/TeamList');
+        await authenticatedPage.getByRole('button', { name: 'Menu' }).waitFor({ timeout: 10000 });
+        await authenticatedPage.getByRole('button', { name: 'Menu' }).click();
+        await authenticatedPage.getByRole('button', { name: 'Manage Users' }).click();
+
+        await expect(authenticatedPage.getByRole('heading', { name: 'Manage Users' })).toBeVisible();
+        await expect(authenticatedPage.getByText('Members (2)')).toBeVisible({ timeout: 10000 });
+        await expect(authenticatedPage.getByText('otheruser')).toBeVisible();
+    });
+});
+
 test.describe('Manage Users (list sharing)', () => {
     test('owner can open Manage Users drawer', async ({ authenticatedPage }) => {
         await apiCreateList('Shared List');

--- a/e2e/tests/todo-list.spec.ts
+++ b/e2e/tests/todo-list.spec.ts
@@ -1,0 +1,77 @@
+import { apiAddItem, apiCreateList } from '../api-helpers';
+import { expect, test } from '../fixtures';
+
+const LIST_TITLE = 'My Tasks';
+
+test.describe('TODO list', () => {
+    test('shows "No tasks yet" empty state', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE, 'todo');
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+        await expect(authenticatedPage.getByText('No tasks yet')).toBeVisible();
+    });
+
+    test('add task dialog title is "Add New Task"', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE, 'todo');
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.locator('button[class*="border-primary"]').first().click();
+        await expect(authenticatedPage.getByText('Add New Task', { exact: true })).toBeVisible();
+    });
+
+    test('add task dialog shows due date field not quantity/unit', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE, 'todo');
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.locator('button[class*="border-primary"]').first().click();
+        await expect(authenticatedPage.getByText('Due Date (Optional)')).toBeVisible();
+        await expect(authenticatedPage.getByLabel('Quantity')).not.toBeVisible();
+        await expect(authenticatedPage.getByLabel('Unit')).not.toBeVisible();
+    });
+
+    test('can add a task without a due date', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE, 'todo');
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.locator('button[class*="border-primary"]').first().click();
+        await authenticatedPage.getByPlaceholder('Enter item name...').fill('Buy groceries');
+        await authenticatedPage.getByRole('button', { name: 'Add Item' }).click();
+
+        await expect(authenticatedPage.getByText('Buy groceries')).toBeVisible();
+    });
+
+    test('can add a task with a due date', async ({ authenticatedPage }) => {
+        await apiCreateList(LIST_TITLE, 'todo');
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await authenticatedPage.locator('button[class*="border-primary"]').first().click();
+        await authenticatedPage.getByPlaceholder('Enter item name...').fill('Pay bills');
+
+        // Open the date picker
+        await authenticatedPage.getByRole('button', { name: 'Pick a date' }).click();
+
+        // Click the last available (enabled) day button in the calendar
+        const dayButtons = authenticatedPage.locator('table button:not([disabled])');
+        await dayButtons.last().click();
+
+        // Picker trigger now shows a formatted date instead of "Pick a date"
+        await expect(authenticatedPage.getByRole('button', { name: 'Pick a date' })).not.toBeVisible();
+
+        await authenticatedPage.getByRole('button', { name: 'Add Item' }).click();
+        await expect(authenticatedPage.getByText('Pay bills')).toBeVisible();
+        // Due date badge (dd/MM/yyyy) appears alongside the task
+        await expect(authenticatedPage.locator('text=/\\d{2}\\/\\d{2}\\/\\d{4}/').first()).toBeVisible();
+    });
+
+    test('due date badge renders on tasks added via API', async ({ authenticatedPage }) => {
+        // Use a fixed future date so the expected badge text is deterministic
+        const dueDateIso = '2030-06-15T12:00:00.000Z';
+        const expectedBadgeText = '15/06/2030';
+
+        await apiCreateList(LIST_TITLE, 'todo');
+        await apiAddItem(LIST_TITLE, 'Call dentist', { dueDate: dueDateIso });
+        await authenticatedPage.goto(`/list/${LIST_TITLE}`);
+
+        await expect(authenticatedPage.getByText('Call dentist')).toBeVisible();
+        await expect(authenticatedPage.getByText(expectedBadgeText)).toBeVisible();
+    });
+});

--- a/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.tsx
+++ b/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.tsx
@@ -106,6 +106,7 @@ export const AddFromRecipeDrawer = ({ open, onOpenChange, listTitle, listItems }
             <RippleButton
                 size="icon"
                 variant="ghost"
+                aria-label="Add from recipe"
                 className="h-12 w-12 rounded-full"
                 onClick={() => onOpenChange(true)}
             >


### PR DESCRIPTION
## Summary

- **TODO list flow**: 6 tests covering empty state, \"Add New Task\" dialog (different title/fields vs shopping), due date picker interaction, due date badge rendering
- **Add From Recipe drawer (items page)**: 7 tests covering the two-step book-icon flow — open, search, select recipe → ingredients, add to list, already-in-list label, back nav, cancel
- **PWA Web Share Target**: 3 tests covering `/share` redirect, pre-filled URL in Create Recipe drawer, and no-url case
- **Share on creation**: 1 test verifying a list can be shared with a user via the Add List dialog
- **Source fix**: added `aria-label=\"Add from recipe\"` to `AddFromRecipeDrawer` trigger button (was unreachable by accessible selector)
- **Helpers**: `dueDate` support in `apiAddItem`, TODO + AddFromRecipe methods in `ItemsPage` page object

## Test plan

- [x] 71/71 tests pass (`bun run test:e2e`)
- [x] Zero lint issues (`bun run lint:fix`)
- [x] Zero type errors (`bun run tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)