### PR TITLE
feat(web): calendar UX refinements

### DIFF
--- a/packages/web/src/components/Calendar/DayTodoList/index.tsx
+++ b/packages/web/src/components/Calendar/DayTodoList/index.tsx
@@ -1,5 +1,6 @@
 import type { Label } from '@shoppingo/types';
 import { Checkbox } from '../../ui/checkbox';
+import { SwipeableRow } from '../SwipeableRow';
 
 export interface DayTodoItem {
     todoId: string;
@@ -14,26 +15,31 @@ export interface DayTodoListProps {
     items: DayTodoItem[];
     labels: Label[];
     onToggle: (todoId: string, occurrenceDay: string) => void;
+    onDelete: (todoId: string) => void;
 }
 
-export const DayTodoList = ({ items, onToggle }: DayTodoListProps) => {
+export const DayTodoList = ({ items, onToggle, onDelete }: DayTodoListProps) => {
     if (items.length === 0) {
         return <p className="text-sm text-muted-foreground py-4 text-center">No todos for this day</p>;
     }
     return (
         <ul className="space-y-2 py-2">
             {items.map((item) => (
-                <li
-                    key={`${item.todoId}-${item.occurrenceDay}`}
-                    className="flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2"
-                >
-                    <span
-                        className="w-1 self-stretch rounded"
-                        style={{ backgroundColor: item.labelColor ?? 'transparent' }}
-                    />
-                    <Checkbox checked={item.done} onCheckedChange={() => onToggle(item.todoId, item.occurrenceDay)} />
-                    <span className="text-xs text-muted-foreground w-12">{item.time ?? 'all day'}</span>
-                    <span className={item.done ? 'line-through text-muted-foreground' : ''}>{item.title}</span>
+                <li key={`${item.todoId}-${item.occurrenceDay}`} data-todo-title={item.title}>
+                    <SwipeableRow onDelete={() => onDelete(item.todoId)}>
+                        <div className="flex items-center gap-3 rounded-lg bg-muted/40 px-3 py-2">
+                            <span
+                                className="w-1 self-stretch rounded"
+                                style={{ backgroundColor: item.labelColor ?? 'transparent' }}
+                            />
+                            <Checkbox
+                                checked={item.done}
+                                onCheckedChange={() => onToggle(item.todoId, item.occurrenceDay)}
+                            />
+                            <span className="text-xs text-muted-foreground w-12">{item.time ?? 'all day'}</span>
+                            <span className={item.done ? 'line-through text-muted-foreground' : ''}>{item.title}</span>
+                        </div>
+                    </SwipeableRow>
                 </li>
             ))}
         </ul>

--- a/packages/web/src/components/Calendar/InboxDrawer/index.tsx
+++ b/packages/web/src/components/Calendar/InboxDrawer/index.tsx
@@ -1,12 +1,14 @@
 import type { Todo } from '@shoppingo/types';
-import { ChevronDown, ChevronUp, Inbox } from 'lucide-react';
+import { ChevronDown, ChevronUp, GripVertical, Inbox } from 'lucide-react';
 import { useState } from 'react';
+import { SwipeableRow } from '../SwipeableRow';
 
 export interface InboxDrawerProps {
     todos: Todo[]; // undated todos
+    onDelete: (todoId: string) => void;
 }
 
-export const InboxDrawer = ({ todos }: InboxDrawerProps) => {
+export const InboxDrawer = ({ todos, onDelete }: InboxDrawerProps) => {
     const [open, setOpen] = useState(false);
 
     return (
@@ -25,23 +27,32 @@ export const InboxDrawer = ({ todos }: InboxDrawerProps) => {
                     {open ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
                 </button>
                 {open && (
-                    <ul className="max-h-48 overflow-y-auto px-4 pb-3 space-y-2">
+                    <ul className="max-h-48 overflow-y-auto px-4 pb-3 space-y-1.5">
                         {todos.length === 0 && (
                             <li className="text-sm text-muted-foreground py-2">Nothing unscheduled</li>
                         )}
                         {todos.map((todo) => (
-                            <li
-                                key={todo.id}
-                                data-testid={`inbox-item-${todo.id}`}
-                                data-todo-title={todo.title}
-                                draggable
-                                onDragStart={(e) => {
-                                    e.dataTransfer.setData('text/plain', todo.id);
-                                    e.dataTransfer.effectAllowed = 'move';
-                                }}
-                                className="cursor-grab rounded-lg bg-muted/40 px-3 py-2 text-sm active:cursor-grabbing"
-                            >
-                                {todo.title}
+                            <li key={todo.id} data-todo-title={todo.title} className="flex items-center gap-2">
+                                <button
+                                    type="button"
+                                    data-testid={`inbox-item-${todo.id}`}
+                                    draggable
+                                    aria-label="Drag to schedule"
+                                    onDragStart={(e) => {
+                                        e.dataTransfer.setData('text/plain', todo.id);
+                                        e.dataTransfer.effectAllowed = 'move';
+                                    }}
+                                    className="shrink-0 cursor-grab text-muted-foreground active:cursor-grabbing"
+                                >
+                                    <GripVertical className="h-4 w-4" />
+                                </button>
+                                <div className="min-w-0 flex-1">
+                                    <SwipeableRow onDelete={() => onDelete(todo.id)}>
+                                        <div className="truncate rounded-lg bg-muted/40 px-3 py-1.5 text-sm">
+                                            {todo.title}
+                                        </div>
+                                    </SwipeableRow>
+                                </div>
                             </li>
                         ))}
                     </ul>

--- a/packages/web/src/components/Calendar/SwipeableRow/index.tsx
+++ b/packages/web/src/components/Calendar/SwipeableRow/index.tsx
@@ -1,0 +1,40 @@
+import { Trash2 } from 'lucide-react';
+import { animate, motion, type PanInfo, useMotionValue } from 'motion/react';
+import type { ReactNode } from 'react';
+
+const DELETE_THRESHOLD = -80;
+
+export interface SwipeableRowProps {
+    children: ReactNode;
+    onDelete: () => void;
+}
+
+export const SwipeableRow = ({ children, onDelete }: SwipeableRowProps) => {
+    const x = useMotionValue(0);
+
+    const handleDragEnd = (_: unknown, info: PanInfo): void => {
+        if (info.offset.x < DELETE_THRESHOLD) {
+            onDelete();
+        } else {
+            animate(x, 0, { type: 'spring', stiffness: 400, damping: 40 });
+        }
+    };
+
+    return (
+        <div className="relative overflow-hidden rounded-lg">
+            <div className="absolute inset-y-0 right-0 flex items-center rounded-lg bg-destructive px-4 text-destructive-foreground">
+                <Trash2 className="h-4 w-4" />
+            </div>
+            <motion.div
+                drag="x"
+                dragConstraints={{ left: -120, right: 0 }}
+                dragElastic={0.08}
+                style={{ x }}
+                onDragEnd={handleDragEnd}
+                className="relative bg-background"
+            >
+                {children}
+            </motion.div>
+        </div>
+    );
+};

--- a/packages/web/src/components/Calendar/WeekAgenda/index.tsx
+++ b/packages/web/src/components/Calendar/WeekAgenda/index.tsx
@@ -1,0 +1,30 @@
+import type { Label } from '@shoppingo/types';
+import { format } from 'date-fns';
+import type { AgendaDay } from '../../../utils/calendar';
+import { DayTodoList } from '../DayTodoList';
+
+export interface WeekAgendaProps {
+    days: AgendaDay[];
+    labels: Label[];
+    onToggle: (todoId: string, occurrenceDay: string) => void;
+    onDelete: (todoId: string) => void;
+}
+
+export const WeekAgenda = ({ days, labels, onToggle, onDelete }: WeekAgendaProps) => {
+    const withItems = days.filter((d) => d.items.length > 0);
+
+    if (withItems.length === 0) {
+        return <p className="text-sm text-muted-foreground py-6 text-center">No upcoming todos this week</p>;
+    }
+
+    return (
+        <div className="space-y-3 pb-44">
+            {withItems.map(({ day, items }) => (
+                <div key={day.toISOString()}>
+                    <h3 className="text-sm font-medium text-muted-foreground">{format(day, 'EEE d MMM')}</h3>
+                    <DayTodoList items={items} labels={labels} onToggle={onToggle} onDelete={onDelete} />
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/packages/web/src/components/ToolBar/AddTodoDrawer/index.tsx
+++ b/packages/web/src/components/ToolBar/AddTodoDrawer/index.tsx
@@ -103,11 +103,11 @@ export const AddTodoDrawer = ({ open, onOpenChange, onAdd, labels, prefillDate }
                 </RippleButton>
             </DrawerTrigger>
             <DrawerContent>
-                <div className="w-full sm:mx-auto sm:max-w-[400px]">
-                    <DrawerHeader>
+                <div className="flex w-full flex-col max-h-[90vh] sm:mx-auto sm:max-w-[400px]">
+                    <DrawerHeader className="flex-none">
                         <DrawerTitle>Add Todo</DrawerTitle>
                     </DrawerHeader>
-                    <div className="p-4 pb-0 space-y-4">
+                    <div className="flex-1 overflow-y-auto p-4 pb-0 space-y-4">
                         <div className="space-y-2">
                             <Label htmlFor={titleId}>Title</Label>
                             <Input
@@ -133,7 +133,7 @@ export const AddTodoDrawer = ({ open, onOpenChange, onAdd, labels, prefillDate }
                         <LabelSelect labels={labels} value={labelId} onChange={setLabelId} />
                         <RecurrenceField value={recurrence} onChange={setRecurrence} />
                     </div>
-                    <DrawerFooter>
+                    <DrawerFooter className="flex-none">
                         <Button onClick={handleSubmit} disabled={isLoading}>
                             Add Todo
                         </Button>

--- a/packages/web/src/hooks/useLabels.ts
+++ b/packages/web/src/hooks/useLabels.ts
@@ -9,7 +9,7 @@ export const useLabels = () => {
         queryClient.invalidateQueries('todos');
     };
 
-    const { data, isLoading } = useQuery<Label[]>(getLabelsQuery());
+    const { data, isLoading, refetch } = useQuery<Label[]>(getLabelsQuery());
 
     const createMutation = useMutation((body: { name: string; color: string }) => apiCreate(body), {
         onSuccess: invalidate,
@@ -23,6 +23,7 @@ export const useLabels = () => {
     return {
         labels: data ?? [],
         isLoading,
+        refetch,
         createLabel: (body: { name: string; color: string }) => createMutation.mutateAsync(body),
         updateLabel: (id: string, body: { name?: string; color?: string }) => updateMutation.mutateAsync({ id, body }),
         deleteLabel: (id: string) => deleteMutation.mutateAsync(id),

--- a/packages/web/src/pages/CalendarPage/index.test.tsx
+++ b/packages/web/src/pages/CalendarPage/index.test.tsx
@@ -5,6 +5,9 @@ import CalendarPage from './index';
 
 // ToolBar pulls in auth/user/router providers; stub it for this unit test.
 vi.mock('../../components/ToolBar', () => ({ default: () => null }));
+vi.mock('../../contexts/PullToRefreshContext', () => ({
+    usePullToRefreshContext: () => ({ registerRefresh: () => () => {} }),
+}));
 vi.mock('../../hooks/useTodos', () => ({
     useTodos: () => ({
         todos: [
@@ -23,10 +26,12 @@ vi.mock('../../hooks/useTodos', () => ({
         createTodo: vi.fn(),
         updateTodo: vi.fn(),
         completeTodo: vi.fn(),
+        deleteTodo: vi.fn(),
+        refetch: vi.fn(),
     }),
 }));
 vi.mock('../../hooks/useLabels', () => ({
-    useLabels: () => ({ labels: [], isLoading: false }),
+    useLabels: () => ({ labels: [], isLoading: false, refetch: vi.fn() }),
 }));
 
 describe('CalendarPage', () => {

--- a/packages/web/src/pages/CalendarPage/index.tsx
+++ b/packages/web/src/pages/CalendarPage/index.tsx
@@ -1,24 +1,39 @@
 import { addMonths, endOfMonth, format, startOfMonth } from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CreateTodoBody } from '../../api';
 import { DayTodoList } from '../../components/Calendar/DayTodoList';
 import { InboxDrawer } from '../../components/Calendar/InboxDrawer';
 import { LabelFilter } from '../../components/Calendar/LabelFilter';
 import { MonthGrid } from '../../components/Calendar/MonthGrid';
+import { WeekAgenda } from '../../components/Calendar/WeekAgenda';
 import ToolBar from '../../components/ToolBar';
 import { Button } from '../../components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../components/ui/select';
+import { usePullToRefreshContext } from '../../contexts/PullToRefreshContext';
 import { useLabels } from '../../hooks/useLabels';
 import { useTodos } from '../../hooks/useTodos';
-import { buildCalendarDayData } from '../../utils/calendar';
+import { buildCalendarDayData, buildWeekAgenda } from '../../utils/calendar';
+
+type CalendarView = 'month' | 'week';
 
 const CalendarPage = () => {
-    const { todos, createTodo, updateTodo, completeTodo } = useTodos();
-    const { labels } = useLabels();
+    const { todos, createTodo, updateTodo, completeTodo, deleteTodo, refetch: refetchTodos } = useTodos();
+    const { labels, refetch: refetchLabels } = useLabels();
+    const { registerRefresh } = usePullToRefreshContext();
 
+    const [view, setView] = useState<CalendarView>('month');
     const [month, setMonth] = useState<Date>(startOfMonth(new Date()));
     const [selectedDay, setSelectedDay] = useState<Date>(new Date());
     const [activeLabels, setActiveLabels] = useState<Set<string>>(new Set());
+
+    useEffect(
+        () =>
+            registerRefresh(async () => {
+                await Promise.all([refetchTodos(), refetchLabels()]);
+            }),
+        [registerRefresh, refetchTodos, refetchLabels]
+    );
 
     const labelColor = useMemo(() => {
         const map = new Map<string, string>();
@@ -31,27 +46,24 @@ const CalendarPage = () => {
         [todos, activeLabels]
     );
 
-    const { dotsByDay, selectedItems } = useMemo(() => {
-        const rangeStart = startOfMonth(month);
-        const rangeEnd = endOfMonth(month);
-        return buildCalendarDayData(visible, month, selectedDay, rangeStart, rangeEnd, labelColor);
-    }, [visible, month, selectedDay, labelColor]);
+    const { dotsByDay, selectedItems } = useMemo(
+        () => buildCalendarDayData(visible, month, selectedDay, startOfMonth(month), endOfMonth(month), labelColor),
+        [visible, month, selectedDay, labelColor]
+    );
+
+    const weekDays = useMemo(() => buildWeekAgenda(visible, new Date(), labelColor), [visible, labelColor]);
 
     const undated = useMemo(() => todos.filter((t) => !t.dueDate), [todos]);
 
     const handleAddTodo = async (body: CreateTodoBody) => {
         await createTodo(body);
     };
-
-    const handleDropOnDay = (todoId: string, day: Date) => {
-        void updateTodo(todoId, { dueDate: day });
-    };
-
+    const handleDropOnDay = (todoId: string, day: Date) => void updateTodo(todoId, { dueDate: day });
     const handleToggle = (todoId: string, occurrenceDay: string) => {
         const todo = todos.find((t) => t.id === todoId);
         void completeTodo(todoId, todo?.recurrence ? occurrenceDay : undefined);
     };
-
+    const handleDelete = (todoId: string) => void deleteTodo(todoId);
     const toggleLabel = (labelId: string) =>
         setActiveLabels((prev) => {
             const next = new Set(prev);
@@ -62,34 +74,64 @@ const CalendarPage = () => {
 
     return (
         <>
-            <div className="flex flex-col">
-                <div className="flex items-center justify-between mb-2">
-                    <Button variant="ghost" size="icon" onClick={() => setMonth((m) => addMonths(m, -1))}>
-                        <ChevronLeft className="h-5 w-5" />
-                    </Button>
-                    <h2 className="text-lg font-semibold">{format(month, 'MMMM yyyy')}</h2>
-                    <Button variant="ghost" size="icon" onClick={() => setMonth((m) => addMonths(m, 1))}>
-                        <ChevronRight className="h-5 w-5" />
-                    </Button>
+            <div className="flex min-h-full flex-col">
+                <div className="sticky top-0 z-10 bg-background pb-2">
+                    <div className="mb-2 flex items-center gap-2">
+                        <Select value={view} onValueChange={(v) => setView(v as CalendarView)}>
+                            <SelectTrigger className="h-9 w-32">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="month">Month</SelectItem>
+                                <SelectItem value="week">Week</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        {view === 'month' && (
+                            <div className="flex flex-1 items-center justify-end gap-1">
+                                <Button variant="ghost" size="icon" onClick={() => setMonth((m) => addMonths(m, -1))}>
+                                    <ChevronLeft className="h-5 w-5" />
+                                </Button>
+                                <span className="text-base font-semibold">{format(month, 'MMM yyyy')}</span>
+                                <Button variant="ghost" size="icon" onClick={() => setMonth((m) => addMonths(m, 1))}>
+                                    <ChevronRight className="h-5 w-5" />
+                                </Button>
+                            </div>
+                        )}
+                    </div>
+
+                    <LabelFilter labels={labels} active={activeLabels} onToggle={toggleLabel} />
+
+                    {view === 'month' && (
+                        <MonthGrid
+                            month={month}
+                            dotsByDay={dotsByDay}
+                            selectedDay={selectedDay}
+                            onSelectDay={setSelectedDay}
+                            onDropTodoOnDay={handleDropOnDay}
+                        />
+                    )}
                 </div>
 
-                <LabelFilter labels={labels} active={activeLabels} onToggle={toggleLabel} />
-
-                <MonthGrid
-                    month={month}
-                    dotsByDay={dotsByDay}
-                    selectedDay={selectedDay}
-                    onSelectDay={setSelectedDay}
-                    onDropTodoOnDay={handleDropOnDay}
-                />
-
-                <div className="mt-3 pb-44">
-                    <h3 className="text-sm font-medium text-muted-foreground">{format(selectedDay, 'EEE d MMMM')}</h3>
-                    <DayTodoList items={selectedItems} labels={labels} onToggle={handleToggle} />
-                </div>
+                {view === 'month' ? (
+                    <div className="mt-3 pb-44">
+                        <h3 className="text-sm font-medium text-muted-foreground">
+                            {format(selectedDay, 'EEE d MMMM')}
+                        </h3>
+                        <DayTodoList
+                            items={selectedItems}
+                            labels={labels}
+                            onToggle={handleToggle}
+                            onDelete={handleDelete}
+                        />
+                    </div>
+                ) : (
+                    <div className="mt-3">
+                        <WeekAgenda days={weekDays} labels={labels} onToggle={handleToggle} onDelete={handleDelete} />
+                    </div>
+                )}
             </div>
 
-            <InboxDrawer todos={undated} />
+            <InboxDrawer todos={undated} onDelete={handleDelete} />
 
             <ToolBar onAddTodo={handleAddTodo} labels={labels} prefillTodoDate={selectedDay} />
         </>

--- a/packages/web/src/utils/calendar.ts
+++ b/packages/web/src/utils/calendar.ts
@@ -1,4 +1,5 @@
 import type { Todo } from '@shoppingo/types';
+import { addDays } from 'date-fns';
 import type { DayTodoItem } from '../components/Calendar/DayTodoList';
 import { dayKey } from '../components/Calendar/MonthGrid';
 import { expandOccurrences, isoDay } from './recurrence';
@@ -57,4 +58,34 @@ export const buildCalendarDayData = (
     }
 
     return { dotsByDay: dots, selectedItems: items };
+};
+
+export interface AgendaDay {
+    day: Date;
+    items: DayTodoItem[];
+}
+
+const collectWeekTodo = (
+    todo: Todo,
+    rangeStart: Date,
+    rangeEnd: Date,
+    byDay: Map<string, DayTodoItem[]>,
+    labelColor: Map<string, string>
+): void => {
+    const color = todo.labelId ? labelColor.get(todo.labelId) : undefined;
+    for (const occ of expandOccurrences(todo, rangeStart, rangeEnd)) {
+        const bucket = byDay.get(dayKey(occ.date));
+        if (bucket) bucket.push(toSelectedItem(todo, color, occ.date, occ.done));
+    }
+};
+
+export const buildWeekAgenda = (visible: Todo[], start: Date, labelColor: Map<string, string>): AgendaDay[] => {
+    const days = Array.from({ length: 7 }, (_, i) => addDays(start, i));
+    const byDay = new Map<string, DayTodoItem[]>(days.map((d) => [dayKey(d), []]));
+
+    for (const todo of visible) {
+        collectWeekTodo(todo, days[0], days[6], byDay, labelColor);
+    }
+
+    return days.map((day) => ({ day, items: byDay.get(dayKey(day)) ?? [] }));
 };


### PR DESCRIPTION
## Overview
Follow-up UX refinements to the todos + calendar feature (#83), from device feedback.

- **Add Todo form**: drawer is height-capped (`max-h-[90vh]`) with scrollable fields and a fixed footer, so the submit button is always reachable on small screens.
- **Swipe-to-delete**: day-list and inbox rows swipe left to delete (`SwipeableRow`, motion-based); the delete affordance is hidden until you swipe.
- **Inbox**: rows are compact and only a grip icon initiates drag-to-schedule (the rest of the row is free for swipe/tap).
- **Week view**: a Month/Week dropdown at the top; Week shows an agenda of the next 7 days (days with todos), for an "upcoming" view.
- **Sticky calendar**: the view dropdown, month nav, label filter and grid are pinned at the top, so selecting different days no longer shifts the calendar around.
- **Pull-to-refresh**: pulling down on the calendar refetches todos + labels.

## Verification
- `bun run --filter @shoppingo/web test` → 314 pass
- `bun run tsc --noEmit` clean; `bun run --filter @shoppingo/web build` succeeds; `bun run lint` clean
- Full Playwright suite → 71/71 pass
- fallow (local, gate new-only) → pass, 0 introduced findings
- Verified on a 390px viewport via screenshots (form fits, swipe hidden at rest, sticky grid, week agenda, compact inbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
