### PR TITLE
fix(web): make add todo drawer scrollable on mobile

### DIFF
--- a/packages/web/src/components/ToolBar/AddTodoDrawer/index.tsx
+++ b/packages/web/src/components/ToolBar/AddTodoDrawer/index.tsx
@@ -103,7 +103,7 @@ export const AddTodoDrawer = ({ open, onOpenChange, onAdd, labels, prefillDate }
                 </RippleButton>
             </DrawerTrigger>
             <DrawerContent>
-                <div className="flex w-full flex-col max-h-[90vh] sm:mx-auto sm:max-w-[400px]">
+                <div className="flex min-h-0 w-full flex-1 flex-col sm:mx-auto sm:max-w-[400px]">
                     <DrawerHeader className="flex-none">
                         <DrawerTitle>Add Todo</DrawerTitle>
                     </DrawerHeader>


### PR DESCRIPTION
## Problem
On mobile, the add-todo drawer on the calendar page clipped its bottom — the submit button and recurrence UI were unreachable, with no scroll.

## Cause
The drawer wrapper used \`max-h-[90vh]\` without \`min-h-0\`. Flex children default to \`min-height: auto\` and refuse to shrink below their content size, so the inner \`overflow-y-auto\` region never received a bounded height. Content overflowed past \`DrawerContent\`'s \`max-h-[85vh]\` cap and off-screen.

## Fix
Wrapper now uses \`min-h-0 flex-1\` (dropping the conflicting \`max-h-[90vh]\`). It shrinks to \`DrawerContent\`'s cap, activating the inner scroll region so the full form — including submit and recurrence fields — is reachable.

## Testing
- \`tsc --noEmit\` clean (CSS-only change)
- Verify manually on a mobile viewport: scroll reaches Add Todo button + recurrence field

🤖 Generated with [Claude Code](https://claude.com/claude-code)