### PR TITLE
fix(pwa): suppress repeated update toast for same pending SW version

### DIFF
--- a/packages/web/src/contexts/PWAContext.tsx
+++ b/packages/web/src/contexts/PWAContext.tsx
@@ -3,6 +3,9 @@ import type React from 'react';
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+const UPDATE_NOTIFIED_KEY = 'pwa-update-notified-at';
+const UPDATE_SNOOZE_MS = 24 * 60 * 60 * 1000;
+
 interface BeforeInstallPromptEvent extends Event {
     prompt: () => Promise<void>;
     userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
@@ -41,6 +44,7 @@ export const PWAProvider: React.FC<PWAProviderProps> = ({ children }) => {
     const [canInstall, setCanInstall] = useState(false);
     const [isInstalled, setIsInstalled] = useState(false);
     const [hasUpdate, setHasUpdate] = useState(false);
+    const [shouldShowUpdateToast, setShouldShowUpdateToast] = useState(false);
     const [isUpdating, setIsUpdating] = useState(false);
     const [isCheckingForUpdate, setIsCheckingForUpdate] = useState(false);
     const toastIdRef = useRef<string | number | null>(null);
@@ -69,6 +73,10 @@ export const PWAProvider: React.FC<PWAProviderProps> = ({ children }) => {
         onRegisterError() {},
         onNeedRefresh() {
             setHasUpdate(true);
+            const lastNotified = localStorage.getItem(UPDATE_NOTIFIED_KEY);
+            if (!lastNotified || Date.now() - Number(lastNotified) > UPDATE_SNOOZE_MS) {
+                setShouldShowUpdateToast(true);
+            }
         },
         onOfflineReady() {},
     });
@@ -85,6 +93,7 @@ export const PWAProvider: React.FC<PWAProviderProps> = ({ children }) => {
     }, [isCheckingForUpdate]);
 
     const updateApp = useCallback(() => {
+        localStorage.removeItem(UPDATE_NOTIFIED_KEY);
         if (toastIdRef.current !== null) {
             toast.dismiss(toastIdRef.current);
             toastIdRef.current = null;
@@ -94,7 +103,9 @@ export const PWAProvider: React.FC<PWAProviderProps> = ({ children }) => {
     }, [updateServiceWorker]);
 
     useEffect(() => {
-        if (!hasUpdate) return;
+        if (!shouldShowUpdateToast) return;
+
+        localStorage.setItem(UPDATE_NOTIFIED_KEY, Date.now().toString());
 
         if (toastIdRef.current !== null) {
             toast.dismiss(toastIdRef.current);
@@ -107,7 +118,7 @@ export const PWAProvider: React.FC<PWAProviderProps> = ({ children }) => {
                 onClick: updateApp,
             },
         });
-    }, [hasUpdate, updateApp]);
+    }, [shouldShowUpdateToast, updateApp]);
 
     useEffect(() => {
         const isStandalone =

--- a/packages/web/src/contexts/PWAContext.tsx
+++ b/packages/web/src/contexts/PWAContext.tsx
@@ -1,4 +1,5 @@
 import { useRegisterSW } from 'virtual:pwa-register/react';
+import { RefreshCw } from 'lucide-react';
 import type React from 'react';
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -113,6 +114,7 @@ export const PWAProvider: React.FC<PWAProviderProps> = ({ children }) => {
 
         toastIdRef.current = toast('A new version is available', {
             duration: Number.POSITIVE_INFINITY,
+            icon: <RefreshCw className="h-4 w-4" />,
             action: {
                 label: 'Update',
                 onClick: updateApp,


### PR DESCRIPTION
Once the user has been shown the update notification, snooze it for 24 hours rather than re-showing on every cold start. The toast reappears after 24 hours to avoid leaving users indefinitely outdated, and the snooze is cleared immediately when the user applies the update so the next real update always notifies straight away.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0157i7K71diMdaH391p6Ytfq