### PR TITLE
feat: manual trigger for daily todo reminder

### DIFF
--- a/packages/api/src/interfaces/TodoHandlers/index.test.ts
+++ b/packages/api/src/interfaces/TodoHandlers/index.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'bun:test';
+import * as todoHandlers from './index';
+
+const mockDependencyContainer = {
+    resolve: vi.fn(),
+};
+
+vi.mock('../../dependencies/container', () => ({
+    dependencyContainer: mockDependencyContainer,
+}));
+
+const mockReminderService = {
+    sendDailyReminders: vi.fn(),
+};
+
+type HonoVars = { Variables: { user: { id: string; username: string } } };
+
+const createMockContext = (overrides: { user?: { id: string; username: string } | null } = {}) => {
+    const vars: Record<string, unknown> = {
+        user: 'user' in overrides ? overrides.user : { id: 'u1', username: 'owner' },
+    };
+
+    return {
+        req: { json: vi.fn().mockResolvedValue({}) },
+        json: vi.fn().mockImplementation((payload: unknown, status: number): Response => {
+            return new Response(JSON.stringify(payload), {
+                status,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }),
+        get: (key: string) => vars[key],
+    } as unknown as import('hono').Context<HonoVars>;
+};
+
+describe('runDailyReminder', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockDependencyContainer.resolve.mockImplementation((token: string) => {
+            if (token === 'TodoReminderService') return mockReminderService;
+            return null;
+        });
+    });
+
+    it('triggers the daily reminder fan-out for an authenticated user', async () => {
+        mockReminderService.sendDailyReminders.mockResolvedValue(undefined);
+        const ctx = createMockContext();
+        const response = await todoHandlers.runDailyReminder(ctx);
+        expect(mockReminderService.sendDailyReminders).toHaveBeenCalledTimes(1);
+        expect(mockReminderService.sendDailyReminders.mock.calls[0][0]).toBeInstanceOf(Date);
+        const body = await response.json();
+        expect(body.triggered).toBe(true);
+    });
+
+    it('rejects an unauthenticated caller', async () => {
+        const ctx = createMockContext({ user: null });
+        const response = await todoHandlers.runDailyReminder(ctx);
+        expect(mockReminderService.sendDailyReminders).not.toHaveBeenCalled();
+        expect(response.status).toBe(401);
+    });
+});

--- a/packages/api/src/interfaces/TodoHandlers/index.ts
+++ b/packages/api/src/interfaces/TodoHandlers/index.ts
@@ -1,9 +1,13 @@
 import { dependencyContainer } from '../../dependencies/container';
 import { DependencyToken } from '../../dependencies/types';
+import type { TodoReminderService } from '../../domain/TodoReminderService';
 import type { CreateTodoInput, TodoService, UpdateTodoInput } from '../../domain/TodoService';
 import { withAuth } from '../handlerUtils';
 
 const getTodoService = (): TodoService => dependencyContainer.resolve(DependencyToken.TodoService);
+
+const getTodoReminderService = (): TodoReminderService =>
+    dependencyContainer.resolve(DependencyToken.TodoReminderService);
 
 export const getTodos = withAuth(async (c, user) => {
     return c.json(await getTodoService().getTodosByOwner(user.id), 200);
@@ -30,4 +34,10 @@ export const completeTodo = withAuth(async (c, user) => {
     const id = c.req.param('id');
     const body = await c.req.json<{ date?: string }>().catch(() => ({}) as { date?: string });
     return c.json(await getTodoService().toggleComplete(id, user.id, body.date), 200);
+});
+
+/** Test trigger: run the daily due-todo reminder fan-out now (same path as the 08:30 scheduler). */
+export const runDailyReminder = withAuth(async (c) => {
+    await getTodoReminderService().sendDailyReminders(new Date());
+    return c.json({ triggered: true }, 200);
 });

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -32,7 +32,14 @@ import {
     updateRecipe,
     uploadRecipeImage,
 } from '../interfaces/RecipeHandlers';
-import { completeTodo, createTodo, deleteTodo, getTodos, updateTodo } from '../interfaces/TodoHandlers';
+import {
+    completeTodo,
+    createTodo,
+    deleteTodo,
+    getTodos,
+    runDailyReminder,
+    updateTodo,
+} from '../interfaces/TodoHandlers';
 import { authenticate } from '../middleware/auth';
 
 type Vars = { Variables: { user: { id: string; username: string } } };
@@ -94,6 +101,7 @@ export const createRoutes = (): Hono<Vars> => {
     router.post('/api/todos/:id', authenticate, updateTodo);
     router.delete('/api/todos/:id', authenticate, deleteTodo);
     router.post('/api/todos/:id/complete', authenticate, completeTodo);
+    router.post('/api/todos/reminder/run', authenticate, runDailyReminder);
 
     router.get('/api/labels', authenticate, getLabels);
     router.put('/api/labels', authenticate, createLabel);

--- a/packages/web/src/api/index.ts
+++ b/packages/web/src/api/index.ts
@@ -387,6 +387,14 @@ export const deleteTodo = async (id: string): Promise<void> => {
     });
 };
 
+export const runDailyReminder = async (): Promise<{ triggered: boolean }> => {
+    return await makeRequest({
+        pathname: '/api/todos/reminder/run',
+        method: MethodType.POST,
+        operationString: 'run daily reminder',
+    });
+};
+
 export const completeTodo = async (id: string, date?: string): Promise<Todo> => {
     return await makeRequest({
         pathname: `/api/todos/${encodeURIComponent(id)}/complete`,

--- a/packages/web/src/components/ToolBar/HamburgerMenu/index.tsx
+++ b/packages/web/src/components/ToolBar/HamburgerMenu/index.tsx
@@ -1,6 +1,8 @@
-import { Bell, Download, Loader2, LogOut, Moon, RefreshCw, Sun, Tag, Users } from 'lucide-react';
+import { Bell, BellRing, Download, Loader2, LogOut, Moon, RefreshCw, Sun, Tag, Users } from 'lucide-react';
 import { motion } from 'motion/react';
-import type { ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
+import { toast } from 'sonner';
+import { runDailyReminder } from '../../../api';
 import { Button } from '../../../components/ui/button';
 import { Switch } from '../../../components/ui/switch';
 import { useTheme } from '../../../contexts/ThemeContext';
@@ -78,6 +80,34 @@ const NotificationToggle = () => {
             </div>
             <Switch checked={isSubscribed} onCheckedChange={handleToggle} disabled={isBusy} />
         </button>
+    );
+};
+
+const TestReminderButton = () => {
+    const { isSupported, isSubscribed } = usePushNotifications();
+    const [isSending, setIsSending] = useState(false);
+    if (!isSupported || !isSubscribed) return null;
+
+    const handleClick = async () => {
+        if (isSending) return;
+        setIsSending(true);
+        try {
+            await runDailyReminder();
+            toast.success('Reminder triggered. Push fires only if you have todos due today.');
+        } catch {
+            toast.error('Failed to trigger reminder', {
+                style: { backgroundColor: '#ef4444', color: '#ffffff' },
+            });
+        } finally {
+            setIsSending(false);
+        }
+    };
+
+    return (
+        <Button variant="outline" onClick={() => void handleClick()} disabled={isSending} className={OUTLINE_BTN}>
+            {isSending ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <BellRing className="h-4 w-4 mr-2" />}
+            Send test reminder
+        </Button>
     );
 };
 
@@ -171,6 +201,10 @@ export const HamburgerMenu = ({
 
             <MenuItem delay={0.1}>
                 <NotificationToggle />
+            </MenuItem>
+
+            <MenuItem delay={0.1}>
+                <TestReminderButton />
             </MenuItem>
 
             <MenuItem delay={0.1}>


### PR DESCRIPTION
## What

Adds a way to fire the daily due-todo reminder push **on demand**, for testing — no need to wait for the 08:30 scheduler.

## Changes

**API**
- `runDailyReminder` handler + `POST /api/todos/reminder/run` (auth-required)
- Reuses `TodoReminderService.sendDailyReminders(now)` — same path as the scheduler (full fan-out)
- New test: `TodoHandlers/index.test.ts`

**Web**
- `runDailyReminder()` API client
- "Send test reminder" button in hamburger menu, shown only when push-subscribed (toast feedback)

## Behaviour
No todos due today = no push (mirrors the real reminder).

## How to test
1. Enable notifications (menu toggle)
2. Create a todo due today
3. Menu → "Send test reminder" → push fires

## Verification
- tsc clean · API 384 pass · web 333 pass · web+api build ok

## Note
Full fan-out: any authenticated user hitting the endpoint pushes to **all** users with due todos. Fine for testing/small user base; consider scoping to caller or admin-only if kept permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)