### PR TITLE
feat: surface reminder run counts for debugging

### DIFF
--- a/packages/api/src/domain/TodoReminderService/index.test.ts
+++ b/packages/api/src/domain/TodoReminderService/index.test.ts
@@ -57,7 +57,7 @@ describe('TodoReminderService.sendDailyReminders', () => {
         );
 
     it('sends ONE summary push per owner with all their due todos', async () => {
-        await service([
+        const summary = await service([
             todo({ id: 'a', title: 'Pay rent' }),
             todo({ id: 'b', title: 'Call dentist' }),
         ]).sendDailyReminders(NOW);
@@ -69,6 +69,13 @@ describe('TodoReminderService.sendDailyReminders', () => {
             body: 'Pay rent, Call dentist',
             data: { url: '/calendar' },
         });
+        expect(summary).toEqual({ configured: true, due: 2, owners: 1, subscriptions: 1, sent: 1 });
+    });
+
+    it('reports configured:false without touching the repo', async () => {
+        sender.isConfigured = () => false;
+        const summary = await service([todo({})]).sendDailyReminders(NOW);
+        expect(summary).toEqual({ configured: false, due: 0, owners: 0, subscriptions: 0, sent: 0 });
     });
 
     it('groups by owner — one push each', async () => {
@@ -124,10 +131,11 @@ describe('TodoReminderService.sendDailyReminders', () => {
         expect(sender.send).not.toHaveBeenCalled();
     });
 
-    it('never throws when a send rejects', async () => {
+    it('never throws when a send rejects, and reports zero sent', async () => {
         sender.send = mock(async () => {
             throw new Error('boom');
         });
-        await expect(service([todo({})]).sendDailyReminders(NOW)).resolves.toBeUndefined();
+        const summary = await service([todo({})]).sendDailyReminders(NOW);
+        expect(summary).toEqual({ configured: true, due: 1, owners: 1, subscriptions: 0, sent: 0 });
     });
 });

--- a/packages/api/src/domain/TodoReminderService/index.ts
+++ b/packages/api/src/domain/TodoReminderService/index.ts
@@ -21,6 +21,20 @@ const endOfLocalDay = (now: Date): Date => {
     return end;
 };
 
+/** Outcome of a reminder run — surfaced to the manual trigger for debugging. */
+export interface ReminderSummary {
+    /** Web push has VAPID keys; false means nothing can ever be sent. */
+    configured: boolean;
+    /** Incomplete todos occurring today. */
+    due: number;
+    /** Distinct owners with at least one due todo. */
+    owners: number;
+    /** Push subscriptions targeted across those owners. */
+    subscriptions: number;
+    /** Pushes the browser push service accepted. */
+    sent: number;
+}
+
 /**
  * Sends one summary push per owner for todos due "today".
  *
@@ -34,15 +48,16 @@ export class TodoReminderService {
         private readonly logger?: Logger
     ) {}
 
-    async sendDailyReminders(now: Date): Promise<void> {
-        if (!this.sender.isConfigured()) {
-            return;
+    async sendDailyReminders(now: Date): Promise<ReminderSummary> {
+        const configured = this.sender.isConfigured();
+        if (!configured) {
+            return { configured, due: 0, owners: 0, subscriptions: 0, sent: 0 };
         }
 
         const candidates = await this.todoRepo.findDueCandidates(endOfLocalDay(now));
         const due = candidates.filter((todo) => occursOn(todo, now));
         if (due.length === 0) {
-            return;
+            return { configured, due: 0, owners: 0, subscriptions: 0, sent: 0 };
         }
 
         const byOwner = new Map<string, Todo[]>();
@@ -52,14 +67,24 @@ export class TodoReminderService {
             byOwner.set(todo.ownerId, list);
         }
 
-        await Promise.all([...byOwner.entries()].map(([ownerId, todos]) => this.notifyOwner(ownerId, todos)));
+        const perOwner = await Promise.all(
+            [...byOwner.entries()].map(([ownerId, todos]) => this.notifyOwner(ownerId, todos))
+        );
+
+        return {
+            configured,
+            due: due.length,
+            owners: byOwner.size,
+            subscriptions: perOwner.reduce((n, r) => n + r.subscriptions, 0),
+            sent: perOwner.reduce((n, r) => n + r.sent, 0),
+        };
     }
 
-    private async notifyOwner(ownerId: string, todos: Todo[]): Promise<void> {
+    private async notifyOwner(ownerId: string, todos: Todo[]): Promise<{ subscriptions: number; sent: number }> {
         try {
             const subs = await this.pushRepo.findByUserIds([ownerId]);
             if (subs.length === 0) {
-                return;
+                return { subscriptions: 0, sent: 0 };
             }
 
             const payload = JSON.stringify({
@@ -73,11 +98,14 @@ export class TodoReminderService {
             if (dead.length > 0) {
                 await this.pushRepo.deleteByEndpoints(dead);
             }
+
+            return { subscriptions: subs.length, sent: results.filter((r) => r === 'ok').length };
         } catch (error) {
             this.logger?.error('Todo reminder fan-out failed', {
                 ownerId,
                 error: (error as Error).message,
             });
+            return { subscriptions: 0, sent: 0 };
         }
     }
 }

--- a/packages/api/src/domain/TodoReminderService/index.ts
+++ b/packages/api/src/domain/TodoReminderService/index.ts
@@ -21,6 +21,24 @@ const endOfLocalDay = (now: Date): Date => {
     return end;
 };
 
+const groupByOwner = (todos: Todo[]): Map<string, Todo[]> => {
+    const byOwner = new Map<string, Todo[]>();
+    for (const todo of todos) {
+        const list = byOwner.get(todo.ownerId) ?? [];
+        list.push(todo);
+        byOwner.set(todo.ownerId, list);
+    }
+    return byOwner;
+};
+
+const emptySummary = (configured: boolean): ReminderSummary => ({
+    configured,
+    due: 0,
+    owners: 0,
+    subscriptions: 0,
+    sent: 0,
+});
+
 /** Outcome of a reminder run — surfaced to the manual trigger for debugging. */
 export interface ReminderSummary {
     /** Web push has VAPID keys; false means nothing can ever be sent. */
@@ -51,21 +69,16 @@ export class TodoReminderService {
     async sendDailyReminders(now: Date): Promise<ReminderSummary> {
         const configured = this.sender.isConfigured();
         if (!configured) {
-            return { configured, due: 0, owners: 0, subscriptions: 0, sent: 0 };
+            return emptySummary(configured);
         }
 
         const candidates = await this.todoRepo.findDueCandidates(endOfLocalDay(now));
         const due = candidates.filter((todo) => occursOn(todo, now));
         if (due.length === 0) {
-            return { configured, due: 0, owners: 0, subscriptions: 0, sent: 0 };
+            return emptySummary(configured);
         }
 
-        const byOwner = new Map<string, Todo[]>();
-        for (const todo of due) {
-            const list = byOwner.get(todo.ownerId) ?? [];
-            list.push(todo);
-            byOwner.set(todo.ownerId, list);
-        }
+        const byOwner = groupByOwner(due);
 
         const perOwner = await Promise.all(
             [...byOwner.entries()].map(([ownerId, todos]) => this.notifyOwner(ownerId, todos))

--- a/packages/api/src/interfaces/TodoHandlers/index.test.ts
+++ b/packages/api/src/interfaces/TodoHandlers/index.test.ts
@@ -41,14 +41,20 @@ describe('runDailyReminder', () => {
         });
     });
 
-    it('triggers the daily reminder fan-out for an authenticated user', async () => {
-        mockReminderService.sendDailyReminders.mockResolvedValue(undefined);
+    it('triggers the daily reminder fan-out and returns the run summary', async () => {
+        mockReminderService.sendDailyReminders.mockResolvedValue({
+            configured: true,
+            due: 2,
+            owners: 1,
+            subscriptions: 3,
+            sent: 3,
+        });
         const ctx = createMockContext();
         const response = await todoHandlers.runDailyReminder(ctx);
         expect(mockReminderService.sendDailyReminders).toHaveBeenCalledTimes(1);
         expect(mockReminderService.sendDailyReminders.mock.calls[0][0]).toBeInstanceOf(Date);
         const body = await response.json();
-        expect(body.triggered).toBe(true);
+        expect(body).toEqual({ triggered: true, configured: true, due: 2, owners: 1, subscriptions: 3, sent: 3 });
     });
 
     it('rejects an unauthenticated caller', async () => {

--- a/packages/api/src/interfaces/TodoHandlers/index.ts
+++ b/packages/api/src/interfaces/TodoHandlers/index.ts
@@ -38,6 +38,6 @@ export const completeTodo = withAuth(async (c, user) => {
 
 /** Test trigger: run the daily due-todo reminder fan-out now (same path as the 08:30 scheduler). */
 export const runDailyReminder = withAuth(async (c) => {
-    await getTodoReminderService().sendDailyReminders(new Date());
-    return c.json({ triggered: true }, 200);
+    const summary = await getTodoReminderService().sendDailyReminders(new Date());
+    return c.json({ triggered: true, ...summary }, 200);
 });

--- a/packages/web/src/api/index.ts
+++ b/packages/web/src/api/index.ts
@@ -387,7 +387,16 @@ export const deleteTodo = async (id: string): Promise<void> => {
     });
 };
 
-export const runDailyReminder = async (): Promise<{ triggered: boolean }> => {
+export interface ReminderRunResult {
+    triggered: boolean;
+    configured: boolean;
+    due: number;
+    owners: number;
+    subscriptions: number;
+    sent: number;
+}
+
+export const runDailyReminder = async (): Promise<ReminderRunResult> => {
     return await makeRequest({
         pathname: '/api/todos/reminder/run',
         method: MethodType.POST,

--- a/packages/web/src/components/ToolBar/HamburgerMenu/index.tsx
+++ b/packages/web/src/components/ToolBar/HamburgerMenu/index.tsx
@@ -2,7 +2,7 @@ import { Bell, BellRing, Download, Loader2, LogOut, Moon, RefreshCw, Sun, Tag, U
 import { motion } from 'motion/react';
 import { type ReactNode, useState } from 'react';
 import { toast } from 'sonner';
-import { runDailyReminder } from '../../../api';
+import { type ReminderRunResult, runDailyReminder } from '../../../api';
 import { Button } from '../../../components/ui/button';
 import { Switch } from '../../../components/ui/switch';
 import { useTheme } from '../../../contexts/ThemeContext';
@@ -83,6 +83,20 @@ const NotificationToggle = () => {
     );
 };
 
+const ERROR_TOAST = { style: { backgroundColor: '#ef4444', color: '#ffffff' } };
+
+const showReminderToast = (r: ReminderRunResult): void => {
+    if (!r.configured) {
+        toast.error('Push not configured on the server (VAPID keys missing).', ERROR_TOAST);
+    } else if (r.due === 0) {
+        toast('No todos due today — nothing to send.');
+    } else if (r.subscriptions === 0) {
+        toast.warning('1+ todos due, but no devices subscribed. Enable notifications on this device.');
+    } else {
+        toast.success(`Sent ${r.sent}/${r.subscriptions} push · ${r.due} due across ${r.owners} owner(s).`);
+    }
+};
+
 const TestReminderButton = () => {
     const { isSupported, isSubscribed } = usePushNotifications();
     const [isSending, setIsSending] = useState(false);
@@ -92,22 +106,9 @@ const TestReminderButton = () => {
         if (isSending) return;
         setIsSending(true);
         try {
-            const r = await runDailyReminder();
-            if (!r.configured) {
-                toast.error('Push not configured on the server (VAPID keys missing).', {
-                    style: { backgroundColor: '#ef4444', color: '#ffffff' },
-                });
-            } else if (r.due === 0) {
-                toast('No todos due today — nothing to send.');
-            } else if (r.subscriptions === 0) {
-                toast.warning('1+ todos due, but no devices subscribed. Enable notifications on this device.');
-            } else {
-                toast.success(`Sent ${r.sent}/${r.subscriptions} push · ${r.due} due across ${r.owners} owner(s).`);
-            }
+            showReminderToast(await runDailyReminder());
         } catch {
-            toast.error('Failed to trigger reminder', {
-                style: { backgroundColor: '#ef4444', color: '#ffffff' },
-            });
+            toast.error('Failed to trigger reminder', ERROR_TOAST);
         } finally {
             setIsSending(false);
         }

--- a/packages/web/src/components/ToolBar/HamburgerMenu/index.tsx
+++ b/packages/web/src/components/ToolBar/HamburgerMenu/index.tsx
@@ -92,8 +92,18 @@ const TestReminderButton = () => {
         if (isSending) return;
         setIsSending(true);
         try {
-            await runDailyReminder();
-            toast.success('Reminder triggered. Push fires only if you have todos due today.');
+            const r = await runDailyReminder();
+            if (!r.configured) {
+                toast.error('Push not configured on the server (VAPID keys missing).', {
+                    style: { backgroundColor: '#ef4444', color: '#ffffff' },
+                });
+            } else if (r.due === 0) {
+                toast('No todos due today — nothing to send.');
+            } else if (r.subscriptions === 0) {
+                toast.warning('1+ todos due, but no devices subscribed. Enable notifications on this device.');
+            } else {
+                toast.success(`Sent ${r.sent}/${r.subscriptions} push · ${r.due} due across ${r.owners} owner(s).`);
+            }
         } catch {
             toast.error('Failed to trigger reminder', {
                 style: { backgroundColor: '#ef4444', color: '#ffffff' },


### PR DESCRIPTION
## What

The manual reminder trigger (#94) returned only `{ triggered: true }` — no way to tell whether a push actually went out. This makes the run **observable** so testing gives instant feedback.

## Changes

**API**
- `TodoReminderService.sendDailyReminders` now returns a `ReminderSummary`:
  `{ configured, due, owners, subscriptions, sent }`
- `POST /api/todos/reminder/run` echoes the summary alongside `triggered`
- `notifyOwner` reports per-owner `{ subscriptions, sent }`

**Web**
- "Send test reminder" toast now reports the real outcome:
  - not configured (VAPID missing)
  - no todos due today
  - todos due but **no subscribed devices** (the common phone gotcha)
  - `Sent X/Y push · N due across M owner(s)`

## Why this helps debugging
The earlier silent `triggered:true` hid the three failure modes we hit while testing — server not configured, nothing due, and (most common) the receiving device never subscribed. Now the toast names which one.

## Verification
- fallow audit clean (new fns under complexity threshold) · tsc clean
- API 385 pass · web 333 pass · web+api build ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)