### PR TITLE
fix(api): coerce todo dueDate strings to Dates so reminders fire

### DIFF
--- a/packages/api/src/domain/TodoService/index.test.ts
+++ b/packages/api/src/domain/TodoService/index.test.ts
@@ -104,4 +104,25 @@ describe('TodoService', () => {
         const removed = await svc.toggleComplete(t.id, 'u1', '2026-06-04');
         expect(removed.completedDates).toEqual([]);
     });
+
+    it('coerces a string dueDate to a Date on create', async () => {
+        const t = await svc.createTodo('u1', { title: 'A', dueDate: '2026-06-29T00:00:00.000Z' as never });
+        expect(t.dueDate).toBeInstanceOf(Date);
+        expect((t.dueDate as Date).toISOString()).toBe('2026-06-29T00:00:00.000Z');
+    });
+
+    it('coerces a string recurrence.until to a Date on create', async () => {
+        const t = await svc.createTodo('u1', {
+            title: 'A',
+            dueDate: '2026-06-29T00:00:00.000Z' as never,
+            recurrence: { freq: 'daily', interval: 1, until: '2026-07-29T00:00:00.000Z' as never },
+        });
+        expect(t.recurrence?.until).toBeInstanceOf(Date);
+    });
+
+    it('coerces a string dueDate to a Date on update', async () => {
+        const t = await svc.createTodo('u1', { title: 'A' });
+        const updated = await svc.updateTodo(t.id, 'u1', { dueDate: '2026-06-29T00:00:00.000Z' as never });
+        expect(updated.dueDate).toBeInstanceOf(Date);
+    });
 });

--- a/packages/api/src/domain/TodoService/index.ts
+++ b/packages/api/src/domain/TodoService/index.ts
@@ -16,6 +16,15 @@ export type UpdateTodoInput = Partial<Omit<Todo, 'id' | 'ownerId' | 'dateAdded'>
 const forbidden = () => Object.assign(new Error('Forbidden'), { status: 403 });
 const notFound = () => Object.assign(new Error('Todo not found'), { status: 404 });
 
+/** dueDate/recurrence.until arrive as JSON strings over HTTP; Mongo range queries need real Dates. */
+const coerceDates = <T extends { dueDate?: Date; recurrence?: Recurrence }>(input: T): T => ({
+    ...input,
+    ...(input.dueDate !== undefined && { dueDate: new Date(input.dueDate) }),
+    ...(input.recurrence?.until !== undefined && {
+        recurrence: { ...input.recurrence, until: new Date(input.recurrence.until) },
+    }),
+});
+
 export class TodoService {
     constructor(
         private readonly repo: TodoRepository,
@@ -30,7 +39,8 @@ export class TodoService {
         return todo;
     }
 
-    async createTodo(ownerId: string, input: CreateTodoInput): Promise<Todo> {
+    async createTodo(ownerId: string, rawInput: CreateTodoInput): Promise<Todo> {
+        const input = coerceDates(rawInput);
         const todo: Todo = {
             id: this.idGenerator.generate(),
             ownerId,
@@ -51,9 +61,9 @@ export class TodoService {
         return this.repo.findByOwnerId(ownerId);
     }
 
-    async updateTodo(todoId: string, ownerId: string, input: UpdateTodoInput): Promise<Todo> {
+    async updateTodo(todoId: string, ownerId: string, rawInput: UpdateTodoInput): Promise<Todo> {
         const existing = await this.getOwned(todoId, ownerId);
-        const merged: Todo = { ...existing, ...input };
+        const merged: Todo = { ...existing, ...coerceDates(rawInput) };
         return this.repo.update(todoId, merged);
     }
 


### PR DESCRIPTION
## Problem

A test reminder (and the 08:30 daily scheduler) reported **"No todos due today — nothing to send"** even with todos due today.

## Root cause

`dueDate` (and `recurrence.until`) arrive as JSON **strings** over HTTP. `TodoHandlers` passes the body straight to `TodoService`, which stored them as **BSON strings**. `MongoTodoRepository.findDueCandidates` queries:

```
.find({ done: false, dueDate: { $lte: dayEnd } })
```

where `dayEnd` is a JS `Date` → BSON Date. Mongo `$lte` only matches same-BSON-type values, so a string `dueDate` never matches the Date operand → **zero candidates** → `due === 0` → the toast.

The calendar UI still showed todos because the read path does `new Date(todo.dueDate)`, which parses strings fine. Tests passed because they insert real `Date` objects, masking the mismatch.

## Fix

Coerce `dueDate` and `recurrence.until` to `Date` in `TodoService` create/update via a `coerceDates` helper.

## Tests

+3 in `TodoService/index.test.ts`: string `dueDate` coerced on create, `recurrence.until` coerced on create, `dueDate` coerced on update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)