### PR TITLE
fix(api): match legacy string dueDates in reminder query

### DIFF
--- a/packages/api/src/infrastructure/MongoTodoRepository/index.test.ts
+++ b/packages/api/src/infrastructure/MongoTodoRepository/index.test.ts
@@ -89,7 +89,7 @@ describe('MongoTodoRepository', () => {
         expect((await repo.getById('t2'))?.labelId).toBe('L');
     });
 
-    it('findDueCandidates sends correct query shape', async () => {
+    it('findDueCandidates matches both Date and legacy string dueDates', async () => {
         const dayEnd = new Date('2026-06-25T23:59:59.999Z');
         const mockFind = mock(() => ({ toArray: async () => [] }));
         const mockDb = {
@@ -99,6 +99,9 @@ describe('MongoTodoRepository', () => {
 
         await testRepo.findDueCandidates(dayEnd);
 
-        expect(mockFind).toHaveBeenCalledWith({ done: false, dueDate: { $lte: dayEnd } });
+        expect(mockFind).toHaveBeenCalledWith({
+            done: false,
+            $or: [{ dueDate: { $lte: dayEnd } }, { dueDate: { $lte: dayEnd.toISOString() } }],
+        });
     });
 });

--- a/packages/api/src/infrastructure/MongoTodoRepository/index.ts
+++ b/packages/api/src/infrastructure/MongoTodoRepository/index.ts
@@ -20,8 +20,13 @@ export class MongoTodoRepository implements TodoRepository {
     }
 
     async findDueCandidates(dayEnd: Date): Promise<Todo[]> {
+        // Legacy todos stored dueDate as an ISO string; Mongo $lte won't compare a string
+        // field against a Date operand, so match both types (ISO strings sort lexically).
         return this.collection()
-            .find({ done: false, dueDate: { $lte: dayEnd } })
+            .find({
+                done: false,
+                $or: [{ dueDate: { $lte: dayEnd } }, { dueDate: { $lte: dayEnd.toISOString() } }],
+            })
             .toArray();
     }
 


### PR DESCRIPTION
## Problem

After #98 merged, the test reminder on **shoppingo.imapps.uk** still reported **"No todos due today"** despite todos being due.

## Root cause

#98 coerced *new* writes to `Date`, but todos created **before** it still have `dueDate` stored as an **ISO string** in Mongo. `findDueCandidates` queries:

```
.find({ done: false, dueDate: { $lte: dayEnd } })
```

`dayEnd` is a JS `Date`. Mongo `$lte` won't compare a string-typed field against a Date operand, so every pre-existing (string-dueDate) todo is skipped → zero candidates → the toast. No amount of new writes fixes the old rows.

## Fix

Match both BSON types with `$or`:

```
$or: [{ dueDate: { $lte: dayEnd } }, { dueDate: { $lte: dayEnd.toISOString() } }]
```

- Date clause → new writes (post-#98).
- ISO-string clause → legacy rows (ISO 8601 sorts lexically, so string `$lte` is correct).

Downstream `occursOn` / `expandOccurrences` already parses either type, so no other change needed. Fixes existing prod data with **no DB migration**.

## Tests

Updated the `findDueCandidates` query-shape test to assert the `$or`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)