### PR TITLE
fix(api): set file extension on MinIO image object keys

### DIFF
--- a/packages/api/src/domain/ImageService/index.test.ts
+++ b/packages/api/src/domain/ImageService/index.test.ts
@@ -148,8 +148,8 @@ describe('ImageService', () => {
 
                 const result = await imageService.getImage('test-image');
 
-                expect(mockImageStore.calls.getHeadObject[0]).toEqual(['test-image']);
-                expect(mockImageStore.calls.getObjectStream[0]).toEqual(['test-image']);
+                expect(mockImageStore.calls.getHeadObject[0]).toEqual(['test-image.webp']);
+                expect(mockImageStore.calls.getObjectStream[0]).toEqual(['test-image.webp']);
                 expect(result.stream).toBe(mockStream);
                 expect(result.contentType).toBe('image/png');
                 expect(result.cacheControl).toBe('public, max-age=31536000, immutable');
@@ -187,7 +187,7 @@ describe('ImageService', () => {
                     'Minimalistic flat icon of a shopping-cart drawn in a simple, clean style, this is going to be a icon for my shopping list item. Bright solid colors, soft rounded edges, modern vector look, no text.',
                 ]);
                 expect(mockImageStore.calls.putObject[0]).toEqual([
-                    'shopping-cart',
+                    'shopping-cart.webp',
                     mockBuffer,
                     { contentType: 'image/webp' },
                 ]);

--- a/packages/api/src/domain/ImageService/index.ts
+++ b/packages/api/src/domain/ImageService/index.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@imapps/api-utils';
 
 import { imageGenerationFailuresTotal, imagesGeneratedTotal, imagesServedTotal } from '../../infrastructure/metrics';
+import { withImageExtension } from '../../infrastructure/objectKey';
 import type { ImageGenerator, ImageStore } from './types';
 
 export class ImageService {
@@ -21,12 +22,14 @@ export class ImageService {
             }
 
             const normalisedName = name.trim().toLowerCase();
+            // AI item images are always WebP, so the storage key carries a fixed .webp extension.
+            const storageKey = withImageExtension(normalisedName, 'image/webp');
 
             // Try to fetch from store first
             try {
-                const head = await this.store.getHeadObject(normalisedName);
+                const head = await this.store.getHeadObject(storageKey);
                 const contentType = head?.metaData?.['content-type'] ?? 'image/webp';
-                const stream = await this.store.getObjectStream(normalisedName);
+                const stream = await this.store.getObjectStream(storageKey);
 
                 this.logger?.info('Image retrieved from cache', {
                     itemName: normalisedName,
@@ -69,7 +72,7 @@ export class ImageService {
 
             // Store the generated image (fire and forget)
             try {
-                await this.store.putObject(normalisedName, buffer, { contentType });
+                await this.store.putObject(storageKey, buffer, { contentType });
             } catch (uploadErr) {
                 this.logger?.error('Failed to store generated image', {
                     itemName: normalisedName,

--- a/packages/api/src/domain/RecipeImageService/index.test.ts
+++ b/packages/api/src/domain/RecipeImageService/index.test.ts
@@ -105,7 +105,7 @@ describe('RecipeImageService', () => {
 
             const key = await service.generateRecipeImage('rec-1', 'Lemon Chicken', ingredients);
 
-            expect(key).toBe('recipe-image/rec-1');
+            expect(key).toBe('recipe-image/rec-1.webp');
             expect(mockGenerator.calls.length).toBe(0);
             expect(mockStore.calls.putObject.length).toBe(0);
         });
@@ -115,12 +115,12 @@ describe('RecipeImageService', () => {
 
             const key = await service.generateRecipeImage('rec-2', 'Lemon Chicken', ingredients);
 
-            expect(key).toBe('recipe-image/rec-2');
+            expect(key).toBe('recipe-image/rec-2.webp');
             expect(mockGenerator.calls.length).toBe(1);
             expect(mockGenerator.calls[0][0]).toBe(
                 'Appetising food photography of Lemon Chicken, featuring chicken, garlic, lemon, soft natural lighting, shallow depth of field, served on a wooden table, no text, no watermark.'
             );
-            expect(mockStore.calls.putObject[0][0]).toBe('recipe-image/rec-2');
+            expect(mockStore.calls.putObject[0][0]).toBe('recipe-image/rec-2.webp');
         });
 
         it('builds prompt with no ingredient clause when ingredients empty', async () => {
@@ -161,7 +161,7 @@ describe('RecipeImageService', () => {
 
             const key = await serviceNoLogger.generateRecipeImage('rec-6', 'Title', ingredients);
 
-            expect(key).toBe('recipe-image/rec-6');
+            expect(key).toBe('recipe-image/rec-6.webp');
         });
     });
 });

--- a/packages/api/src/domain/RecipeImageService/index.ts
+++ b/packages/api/src/domain/RecipeImageService/index.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@imapps/api-utils';
 import type { Ingredient } from '@shoppingo/types';
 
+import { withImageExtension } from '../../infrastructure/objectKey';
 import type { ImageGenerator, ImageStore } from '../ImageService/types';
 
 export class RecipeImageService {
@@ -17,7 +18,8 @@ export class RecipeImageService {
         force = false
     ): Promise<string> {
         // Keyed by recipe id so each recipe owns a unique, immutable AI image (no cross-recipe sharing).
-        const key = `recipe-image/${recipeId}`;
+        // AI images are always WebP, so the key carries a fixed .webp extension.
+        const key = withImageExtension(`recipe-image/${recipeId}`, 'image/webp');
 
         if (!force) {
             try {

--- a/packages/api/src/infrastructure/objectKey.test.ts
+++ b/packages/api/src/infrastructure/objectKey.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+
+import { withImageExtension } from './objectKey';
+
+describe('withImageExtension', () => {
+    it('appends the extension derived from known image content-types', () => {
+        expect(withImageExtension('carrot', 'image/webp')).toBe('carrot.webp');
+        expect(withImageExtension('carrot', 'image/png')).toBe('carrot.png');
+        expect(withImageExtension('carrot', 'image/jpeg')).toBe('carrot.jpg');
+        expect(withImageExtension('recipe-image/abc', 'image/svg+xml')).toBe('recipe-image/abc.svg');
+    });
+
+    it('ignores charset parameters and casing', () => {
+        expect(withImageExtension('carrot', 'IMAGE/PNG; charset=binary')).toBe('carrot.png');
+    });
+
+    it('falls back to the subtype for other image types', () => {
+        expect(withImageExtension('carrot', 'image/heic')).toBe('carrot.heic');
+    });
+
+    it('is idempotent when the extension is already present', () => {
+        expect(withImageExtension('carrot.webp', 'image/webp')).toBe('carrot.webp');
+        expect(withImageExtension('carrot.WEBP', 'image/webp')).toBe('carrot.WEBP');
+    });
+
+    it('leaves the key unchanged for missing or non-image content-types', () => {
+        expect(withImageExtension('carrot', undefined)).toBe('carrot');
+        expect(withImageExtension('carrot', '')).toBe('carrot');
+        expect(withImageExtension('carrot', 'application/json')).toBe('carrot');
+    });
+});

--- a/packages/api/src/infrastructure/objectKey.ts
+++ b/packages/api/src/infrastructure/objectKey.ts
@@ -1,0 +1,35 @@
+const CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
+    'image/webp': 'webp',
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/gif': 'gif',
+    'image/avif': 'avif',
+    'image/svg+xml': 'svg',
+};
+
+/** Resolve a file extension (no dot) for a content-type, or undefined if it is not a recognised image type. */
+const extensionForContentType = (contentType?: string): string | undefined => {
+    const normalised = contentType?.split(';')[0]?.trim().toLowerCase();
+    if (!normalised) {
+        return undefined;
+    }
+    if (CONTENT_TYPE_EXTENSIONS[normalised]) {
+        return CONTENT_TYPE_EXTENSIONS[normalised];
+    }
+    // Fall back to the subtype for other image/* types (e.g. image/heic -> heic).
+    const [type, subtype] = normalised.split('/');
+    if (type === 'image' && subtype) {
+        return subtype.replace(/\+.*$/, '');
+    }
+    return undefined;
+};
+
+/** Append the content-type's file extension to an object key. Idempotent; returns the key unchanged for unknown types. */
+export const withImageExtension = (key: string, contentType?: string): string => {
+    const ext = extensionForContentType(contentType);
+    if (!ext || key.toLowerCase().endsWith(`.${ext}`)) {
+        return key;
+    }
+    return `${key}.${ext}`;
+};

--- a/packages/api/src/interfaces/RecipeHandlers/index.test.ts
+++ b/packages/api/src/interfaces/RecipeHandlers/index.test.ts
@@ -539,6 +539,9 @@ describe('RecipeHandlers', () => {
             });
             const response = await recipeHandlers.uploadRecipeImage(ctx);
             expect(response.status).toBe(200);
+            const storedKey = mockBucketStore.putObject.mock.calls[0][0] as string;
+            expect(storedKey.endsWith('.jpg')).toBe(true);
+            expect(mockRecipeService.setCoverImageKey.mock.calls[0][1]).toBe(storedKey);
         });
 
         it('returns error on bucket failure', async () => {

--- a/packages/api/src/interfaces/RecipeHandlers/index.ts
+++ b/packages/api/src/interfaces/RecipeHandlers/index.ts
@@ -4,6 +4,7 @@ import type { Context } from 'hono';
 import { dependencyContainer } from '../../dependencies/container';
 import { DependencyToken } from '../../dependencies/types';
 import type { RecipeService } from '../../domain/RecipeService';
+import { withImageExtension } from '../../infrastructure/objectKey';
 import type { HonoVars } from '../handlerUtils';
 
 interface HttpError {
@@ -417,7 +418,11 @@ export const uploadRecipeImage = async (c: Context<HonoVars>): Promise<Response>
 
         const fileBuffer = Buffer.from(await imageFile.arrayBuffer());
         // Versioned key so each upload is a distinct, immutable URL (avoids stale browser cache).
-        const imageKey = `recipe-upload/${authenticatedUser.id}/${recipeId}/${Date.now()}`;
+        // Extension derived from the uploaded file's type so the stored object is correctly identified.
+        const imageKey = withImageExtension(
+            `recipe-upload/${authenticatedUser.id}/${recipeId}/${Date.now()}`,
+            mimeType
+        );
 
         const bucketStore = getBucketStore();
         await bucketStore.putObject(imageKey, fileBuffer, { contentType: mimeType });


### PR DESCRIPTION
## Problem
Image objects pushed to MinIO were stored under keys with **no file extension** (e.g. `carrot`, `recipe-image/<id>`, `recipe-upload/<user>/<recipe>/<ts>`). The `Content-Type` metadata was set correctly, but the objects themselves are unidentifiable by type when downloaded or browsed directly in MinIO.

## Fix
New helper `withImageExtension(key, contentType)` appends the correct extension (idempotent, safe on unknown types). Wired into all three upload sites:

- **AI item images** (`ImageService`) — always WebP → fixed `.webp`. Read + write derive the same key.
- **Recipe AI images** (`RecipeImageService`) — always WebP → fixed `.webp`. Key persisted in DB (`aiImageKey`/`coverImageKey`); `startsWith('recipe-image/')` checks unaffected.
- **Recipe cover uploads** (`RecipeHandlers`) — extension from the uploaded file's MIME type.

## Backward compatibility
- Upload keys are persisted verbatim, so existing extensionless objects stay retrievable.
- Derived AI keys (item/recipe) regenerate once under the new `.webp` key on next request.

## Tests
- New `objectKey.test.ts` covers extension mapping, casing/charset, subtype fallback, idempotency, and unknown types.
- Updated `ImageService`, `RecipeImageService`, and `RecipeHandlers` suites to assert the new keys.
- Full API suite green apart from two pre-existing, unrelated failures (auth network test, prom-client metric double-registration) present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)