### PR TITLE
fix(ci): disable husky hooks in release job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,9 @@ jobs:
     permissions:
       contents: write
       packages: read
+    env:
+      # Skip husky hook install; semantic-release's git push must not trigger the local pre-push audit.
+      HUSKY: 0
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem
The `release` job ([failing run](https://github.com/igor-siergiej/shoppingo/actions/runs/28738944425/job/85218132635)) fails at `bunx semantic-release`:

```
git push --tags https://github.com/igor-siergiej/shoppingo HEAD:main
husky - pre-push script failed (code 22)
$ fallow-audit
Downloading fallow (fallow-linux-x64-gnu, latest)…
curl: (22) The requested URL returned error: 404
```

`bun install` runs the `prepare: husky` script, installing the git hooks. `@semantic-release/git` then does `git push --tags HEAD:main`, which fires the local **pre-push** hook → `fallow-audit` → downloads the fallow binary from `releases/latest` → **404** → push fails → release fails.

## Fix
CI must not run local dev git hooks. Set `HUSKY=0` on the `release` job so `bun install` skips installing them. The push then completes normally.

## Not affected
- PR dead-code merge gate runs via `bunx fallow@2.100.0 dead-code` (npm, pinned) — no GitHub binary download, no 404.
- Other PR jobs never `git push`, so the pre-push hook never fires there.

## Follow-up (out of scope)
The fallow `latest` binary download 404 is a real breakage in `@imapps/dev-scripts`' `fallow-audit.sh` (affects fresh local clones with no `.tooling` cache). Worth pinning `FALLOW_VERSION` or fixing the asset URL there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)