### PR TITLE
fix(web): allow letters and pasting in friend code input

### DIFF
--- a/packages/web/src/components/ToolBar/AddFriendDrawer/index.test.tsx
+++ b/packages/web/src/components/ToolBar/AddFriendDrawer/index.test.tsx
@@ -75,6 +75,18 @@ describe('AddFriendDrawer', () => {
         await flush();
     });
 
+    it('enter mode: pasting a mixed-case code with stray characters sanitizes it to an uppercase code', async () => {
+        render(<AddFriendDrawer open onOpenChange={noop} />);
+        fireEvent.click(drawerContent().getByRole('button', { name: 'Enter code' }));
+
+        const otpInput = document.querySelector('input[data-input-otp]') as HTMLInputElement;
+        fireEvent.paste(otpInput, { clipboardData: { getData: () => 'ab-cd 12' } });
+
+        fireEvent.click(drawerContent().getByRole('button', { name: 'Add friend' }));
+        expect(redeemMutate).toHaveBeenCalledWith('ABCD12', expect.anything());
+        await flush();
+    });
+
     it('shows the expired-code error message on a rejected redeem', async () => {
         mockedUseRedeemFriendCode.mockReturnValue({
             mutate: redeemMutate,

--- a/packages/web/src/components/ToolBar/AddFriendDrawer/index.tsx
+++ b/packages/web/src/components/ToolBar/AddFriendDrawer/index.tsx
@@ -1,3 +1,4 @@
+import { REGEXP_ONLY_DIGITS_AND_CHARS } from 'input-otp';
 import { UserPlus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Button } from '../../../components/ui/button';
@@ -15,6 +16,10 @@ type Mode = 'invite' | 'enter';
 
 const OTP_LENGTH = 6;
 const CLOSE_DELAY_MS = 900;
+
+// Codes are generated from an uppercase-letters-and-digits alphabet (see FriendService),
+// so normalize typed/pasted input to match regardless of case or stray whitespace.
+const sanitizeCode = (value: string) => value.toUpperCase().replace(/[^A-Z0-9]/g, '');
 
 const formatCountdown = (secondsLeft: number): string => {
     if (secondsLeft <= 0) return 'Expired';
@@ -173,7 +178,14 @@ export const AddFriendDrawer = ({ open, onOpenChange }: AddFriendDrawerProps) =>
                         ) : (
                             <div className="space-y-4">
                                 <div className="flex justify-center">
-                                    <InputOTP maxLength={OTP_LENGTH} value={otp} onChange={setOtp}>
+                                    <InputOTP
+                                        maxLength={OTP_LENGTH}
+                                        value={otp}
+                                        onChange={(value) => setOtp(sanitizeCode(value))}
+                                        pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+                                        inputMode="text"
+                                        pasteTransformer={sanitizeCode}
+                                    >
                                         <InputOTPGroup>
                                             {[0, 1, 2, 3, 4, 5].map((slotIndex) => (
                                                 <InputOTPSlot key={slotIndex} index={slotIndex} />


### PR DESCRIPTION
Friend codes are generated from an uppercase letters+digits alphabet, but
the redeem input was locked to a numeric keypad (default input-otp
inputMode) with no way to type or paste letters. Switch to a text keyboard,
allow alphanumeric characters via the library's pattern, and normalize
typed/pasted input (uppercase, strip stray characters) so pasted codes with
whitespace or mixed case still redeem correctly.