### PR TITLE
fix(recipe-import): send browser-like headers to reduce 403s from recipe sites

### DIFF
--- a/packages/api/src/infrastructure/HttpPageFetcher/index.test.ts
+++ b/packages/api/src/infrastructure/HttpPageFetcher/index.test.ts
@@ -34,6 +34,15 @@ describe('HttpPageFetcher', () => {
         await expect(new HttpPageFetcher().fetchPage('https://example.com')).rejects.toMatchObject({ status: 502 });
     });
 
+    it('throws a clear message when the target site blocks the request with a 403', async () => {
+        stubFetch(async () => new Response('forbidden', { status: 403, headers: { 'content-type': 'text/html' } }));
+
+        await expect(new HttpPageFetcher().fetchPage('https://example.com')).rejects.toMatchObject({
+            status: 502,
+            message: expect.stringContaining('blocks automated requests'),
+        });
+    });
+
     it('throws 415 on a non-html content type', async () => {
         stubFetch(async () => new Response('{}', { headers: { 'content-type': 'application/json' } }));
 

--- a/packages/api/src/infrastructure/HttpPageFetcher/index.ts
+++ b/packages/api/src/infrastructure/HttpPageFetcher/index.ts
@@ -8,7 +8,7 @@ export interface HttpPageFetcherOptions {
 
 // A realistic desktop UA so recipe sites serve full HTML rather than a bot/challenge page.
 const DEFAULT_USER_AGENT =
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36';
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
 
 export class HttpPageFetcher implements PageFetcher {
     private readonly timeoutMs: number;
@@ -32,7 +32,13 @@ export class HttpPageFetcher implements PageFetcher {
                 redirect: 'follow',
                 headers: {
                     'User-Agent': this.userAgent,
-                    Accept: 'text/html,application/xhtml+xml',
+                    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                    'Accept-Language': 'en-US,en;q=0.9',
+                    'Upgrade-Insecure-Requests': '1',
+                    'Sec-Fetch-Dest': 'document',
+                    'Sec-Fetch-Mode': 'navigate',
+                    'Sec-Fetch-Site': 'none',
+                    'Sec-Fetch-User': '?1',
                 },
             });
         } catch (error) {
@@ -44,6 +50,12 @@ export class HttpPageFetcher implements PageFetcher {
         }
 
         if (!response.ok) {
+            if (response.status === 403 || response.status === 999) {
+                throw Object.assign(
+                    new Error('This site blocks automated requests — paste the ingredients/instructions manually'),
+                    { status: 502 }
+                );
+            }
             throw Object.assign(new Error(`Failed to fetch page: ${response.status}`), { status: 502 });
         }
 

--- a/packages/api/src/infrastructure/HttpPageFetcher/index.ts
+++ b/packages/api/src/infrastructure/HttpPageFetcher/index.ts
@@ -6,9 +6,10 @@ export interface HttpPageFetcherOptions {
     userAgent?: string;
 }
 
-// A realistic desktop UA so recipe sites serve full HTML rather than a bot/challenge page.
-const DEFAULT_USER_AGENT =
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+// Firefox, not Chrome: several recipe sites run WAF rules that specifically flag the extremely
+// common "generic Chrome" UA string used by countless scraping tools/headless browsers, while a
+// Firefox UA (much less commonly spoofed) passes through the same bot checks unblocked.
+const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0';
 
 export class HttpPageFetcher implements PageFetcher {
     private readonly timeoutMs: number;


### PR DESCRIPTION
Many recipe sites' bot detection rejects the import fetch even with a
realistic User-Agent because it lacks other headers a real browser sends
(Accept-Language, Sec-Fetch-*, Upgrade-Insecure-Requests). Add those, and
surface a clearer message when a site still returns 403 so users know to
fall back to manual paste instead of seeing a generic fetch failure.