### PR TITLE
fix(recipe-import): split quantity/unit out of ingredient name

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,13 +29,14 @@
     },
     "packages/api": {
       "name": "@shoppingo/api",
-      "version": "1.55.1",
+      "version": "1.57.2",
       "dependencies": {
         "@imapps/api-utils": "0.6.0",
         "@shoppingo/types": "workspace:*",
         "cheerio": "^1.2.0",
         "dotenv": "^17.2.2",
         "hono": "^4.6.14",
+        "parse-ingredient": "^2.2.0",
         "prom-client": "^15.1.3",
         "sharp": "^0.34.5",
         "typescript": "^5.9.2",
@@ -49,14 +50,14 @@
     },
     "packages/types": {
       "name": "@shoppingo/types",
-      "version": "1.55.1",
+      "version": "1.57.2",
       "dependencies": {
         "date-fns": "^4.1.0",
       },
     },
     "packages/web": {
       "name": "@shoppingo/web",
-      "version": "1.55.1",
+      "version": "1.57.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@imapps/web-utils": "0.5.1",
@@ -1793,6 +1794,8 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
+    "numeric-quantity": ["numeric-quantity@3.2.2", "", {}, "sha512-qHc6mhIySaoqFYCM+foWY0DYYIT0ick1fI+MB9530gJ8XAPDExwXT8eyl3J+PWLIlZy0MCxSLobBjrggN9Z8EQ=="],
+
     "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -1840,6 +1843,8 @@
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-ingredient": ["parse-ingredient@2.2.0", "", { "dependencies": { "numeric-quantity": "^3.2.1" } }, "sha512-0nC1B3AJxZHAXM4zu/57XlZbaXuK6vpZDQcHpwBALU7KRxw5f1O/Tr0x0Srz3vxpn4+AP0NqCLKqnNdkIx9GVQ=="],
 
     "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,6 +15,7 @@
     "cheerio": "^1.2.0",
     "dotenv": "^17.2.2",
     "hono": "^4.6.14",
+    "parse-ingredient": "^2.2.0",
     "prom-client": "^15.1.3",
     "sharp": "^0.34.5",
     "typescript": "^5.9.2",

--- a/packages/api/src/domain/RecipeImportService/index.test.ts
+++ b/packages/api/src/domain/RecipeImportService/index.test.ts
@@ -63,7 +63,9 @@ describe('RecipeImportService', () => {
 
             expect(result.title).toBe('Test Cake');
             expect(result.image).toBe('https://img/cake.jpg');
-            expect(result.ingredients.map((i) => i.name)).toEqual(['200g flour', '3 eggs', '100g sugar']);
+            expect(result.ingredients.map((i) => i.name)).toEqual(['flour', 'eggs', 'sugar']);
+            expect(result.ingredients.map((i) => i.quantity)).toEqual([200, 3, 100]);
+            expect(result.ingredients.map((i) => i.unit)).toEqual(['g', undefined, 'g']);
             expect(result.ingredients[0].id).toBe('id-1');
             expect(result.instructions).toEqual(['Mix.', 'Bake.']);
             expect(result.prepTime).toBe('PT20M');
@@ -131,6 +133,40 @@ describe('RecipeImportService', () => {
         });
     });
 
+    describe('ingredient quantity/unit parsing', () => {
+        it('splits quantity and unit out of the name, leaving name free of measurements', async () => {
+            fetcher.html = jsonLdPage({
+                '@type': 'Recipe',
+                name: 'Parsing',
+                recipeIngredient: ['1/2 cup salt', '2 cloves garlic', '3 eggs', 'salt to taste'],
+                recipeInstructions: ['Do it.'],
+            });
+
+            const result = await service.importFromUrl('https://example.com/parsing');
+
+            expect(result.ingredients).toEqual([
+                { id: 'id-1', name: 'salt', quantity: 0.5, unit: 'cup' },
+                { id: 'id-2', name: 'garlic', quantity: 2, unit: 'cloves' },
+                { id: 'id-3', name: 'eggs', quantity: 3 },
+                { id: 'id-4', name: 'salt to taste' },
+            ]);
+        });
+
+        it('falls back to the raw line as the name when it has no quantity or unit', async () => {
+            fetcher.html = jsonLdPage({
+                '@type': 'Recipe',
+                name: 'No measurements',
+                recipeIngredient: ['flour', 'a pinch of nutmeg'],
+                recipeInstructions: ['Do it.'],
+            });
+
+            const result = await service.importFromUrl('https://example.com/no-measurements');
+
+            expect(result.ingredients.map((i) => i.name)).toEqual(['flour', 'a pinch of nutmeg']);
+            expect(result.ingredients.every((i) => i.quantity === undefined && i.unit === undefined)).toBe(true);
+        });
+    });
+
     describe('Tier 2 — HTML heuristics', () => {
         it('recovers ingredients/instructions from class-based markup (joshuaweissman shape)', async () => {
             fetcher.html = jsonLdPage(
@@ -156,11 +192,9 @@ describe('RecipeImportService', () => {
 
             expect(result.title).toBe('Kimchi');
             expect(result.image).toBe('https://img/kimchi.jpg');
-            expect(result.ingredients.map((i) => i.name)).toEqual([
-                '1 napa cabbage',
-                '1/2 cup salt',
-                '3 tbsp gochugaru',
-            ]);
+            expect(result.ingredients.map((i) => i.name)).toEqual(['napa cabbage', 'salt', 'gochugaru']);
+            expect(result.ingredients.map((i) => i.quantity)).toEqual([1, 0.5, 3]);
+            expect(result.ingredients.map((i) => i.unit)).toEqual([undefined, 'cup', 'tbsp']);
             expect(result.instructions).toEqual(['Salt the cabbage.', 'Rinse and drain.', 'Mix with paste.']);
         });
 
@@ -175,7 +209,9 @@ describe('RecipeImportService', () => {
             const result = await service.importFromUrl('https://example.com/rice');
 
             expect(result.title).toBe('Plain Rice');
-            expect(result.ingredients.map((i) => i.name)).toEqual(['2 cups rice', '4 cups water']);
+            expect(result.ingredients.map((i) => i.name)).toEqual(['rice', 'water']);
+            expect(result.ingredients.map((i) => i.quantity)).toEqual([2, 4]);
+            expect(result.ingredients.map((i) => i.unit)).toEqual(['cups', 'cups']);
             expect(result.instructions).toEqual(['Boil rice in water.']);
         });
 
@@ -231,7 +267,9 @@ describe('RecipeImportService', () => {
             const result = await service.importFromUrl('https://example.com/blog');
 
             expect(result.title).toBe('LLM Dish');
-            expect(result.ingredients.map((i) => i.name)).toEqual(['1 onion', '2 cloves garlic']);
+            expect(result.ingredients.map((i) => i.name)).toEqual(['onion', 'garlic']);
+            expect(result.ingredients.map((i) => i.quantity)).toEqual([1, 2]);
+            expect(result.ingredients.map((i) => i.unit)).toEqual([undefined, 'cloves']);
             expect(result.instructions).toEqual(['Fry onion.', 'Add garlic.']);
         });
 

--- a/packages/api/src/domain/RecipeImportService/index.ts
+++ b/packages/api/src/domain/RecipeImportService/index.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@imapps/api-utils';
 import type { Ingredient, RecipeImportResult } from '@shoppingo/types';
 import * as cheerio from 'cheerio';
+import { parseIngredient } from 'parse-ingredient';
 
 import type { IdGenerator } from '../IdGenerator';
 import type { PageFetcher, RecipeDraft, RecipeTextExtractor } from './types';
@@ -62,7 +63,7 @@ export class RecipeImportService {
 
         return {
             title: draft.title,
-            ingredients: draft.ingredients.map<Ingredient>((name) => ({ id: this.idGenerator.generate(), name })),
+            ingredients: draft.ingredients.map((raw) => this.toIngredient(raw)),
             instructions: draft.instructions,
             link: draft.link,
             ...(draft.image !== undefined && { image: draft.image }),
@@ -83,6 +84,21 @@ export class RecipeImportService {
             throw Object.assign(new Error('URL must be http or https'), { status: 400 });
         }
         return parsed.toString();
+    }
+
+    // Splits a raw ingredient line ("2 cups flour") into { name, quantity, unit } so the
+    // name stays free of measurements — imports also feed the AI image prompt, which
+    // renders garbled results when numbers/units are mixed into the ingredient name.
+    private toIngredient(raw: string): Ingredient {
+        const [parsed] = parseIngredient(raw);
+        const name = parsed?.description ? collapse(parsed.description) : raw;
+
+        return {
+            id: this.idGenerator.generate(),
+            name: name || raw,
+            ...(typeof parsed?.quantity === 'number' && { quantity: parsed.quantity }),
+            ...(parsed?.unitOfMeasure && { unit: parsed.unitOfMeasure }),
+        };
     }
 
     private isInsufficient(draft: RecipeDraft): boolean {


### PR DESCRIPTION
Imported recipe ingredients were storing the full raw line (e.g.
"2 cups flour") as the item name, with quantity/unit left unset. This
polluted the AI image generation prompt, which uses ingredient names,
producing garbled images for imported recipes. Ingredient lines from
all three import tiers (JSON-LD, HTML heuristics, LLM fallback) are
now parsed with parse-ingredient into separate name/quantity/unit
fields, matching the existing Ingredient schema already used by
manually-entered items.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FYbTq3kUHwkQwXAqsRV6xH