### PR TITLE
fix(web): recover shared recipe url from Android's text/title share fields

### DIFF
--- a/e2e/tests/share-target.spec.ts
+++ b/e2e/tests/share-target.spec.ts
@@ -26,4 +26,16 @@ test.describe('PWA Web Share Target', () => {
         // Drawer should NOT auto-open when no sharedUrl
         await expect(authenticatedPage.getByRole('heading', { name: 'Create Recipe' })).not.toBeVisible();
     });
+
+    test('opens "Create Recipe" drawer when the link only arrives in the Android `text` field', async ({
+        authenticatedPage,
+    }) => {
+        // Android's share sheet has no dedicated URL slot — the sharing app (Firefox, Chrome, etc.)
+        // puts the link in `text` instead of `url`.
+        await authenticatedPage.goto('/share?text=https://example.com/recipe&title=Test+Recipe');
+        await authenticatedPage.waitForURL(/\/recipes/, { timeout: 5000 });
+
+        await expect(authenticatedPage.getByRole('heading', { name: 'Create Recipe' })).toBeVisible({ timeout: 5000 });
+        await expect(authenticatedPage.getByPlaceholder('https://...')).toHaveValue('https://example.com/recipe');
+    });
 });

--- a/packages/web/src/pages/ShareTargetPage/index.test.tsx
+++ b/packages/web/src/pages/ShareTargetPage/index.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import ShareTargetPage from './index';
+
+const renderAt = (path: string) => {
+    const router = createMemoryRouter(
+        [
+            { path: '/share', element: <ShareTargetPage /> },
+            { path: '/recipes', element: <div>recipes page</div> },
+        ],
+        { initialEntries: [path] }
+    );
+    render(<RouterProvider router={router} />);
+    return router;
+};
+
+describe('ShareTargetPage', () => {
+    it('carries an explicit url param through to /recipes', () => {
+        const router = renderAt('/share?url=https://example.com/recipe&title=Test');
+        expect(router.state.location.pathname).toBe('/recipes');
+        const params = new URLSearchParams(router.state.location.search);
+        expect(params.get('sharedUrl')).toBe('https://example.com/recipe');
+        expect(params.get('sharedTitle')).toBe('Test');
+    });
+
+    it('falls back to extracting the url from the text param (Android share behaviour)', () => {
+        const router = renderAt('/share?text=https://example.com/recipe&title=Test');
+        const params = new URLSearchParams(router.state.location.search);
+        expect(params.get('sharedUrl')).toBe('https://example.com/recipe');
+    });
+
+    it('falls back to extracting the url from the title param when text is also empty', () => {
+        const router = renderAt('/share?title=Check+this+out+https://example.com/recipe');
+        const params = new URLSearchParams(router.state.location.search);
+        expect(params.get('sharedUrl')).toBe('https://example.com/recipe');
+    });
+
+    it('redirects to /recipes without a sharedUrl when no url can be found', () => {
+        const router = renderAt('/share?title=Test+Recipe');
+        expect(router.state.location.pathname).toBe('/recipes');
+        const params = new URLSearchParams(router.state.location.search);
+        expect(params.get('sharedUrl')).toBeNull();
+    });
+});

--- a/packages/web/src/pages/ShareTargetPage/index.tsx
+++ b/packages/web/src/pages/ShareTargetPage/index.tsx
@@ -1,13 +1,21 @@
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
+// Android's share sheet has no dedicated URL slot: the browser doing the sharing (Firefox,
+// Chrome, etc.) puts the link in the `text` extra, occasionally `title` — `url` is reliably
+// empty. Pull the first URL out of whichever field actually has it.
+const extractUrl = (value: string): string => /https?:\/\/\S+/.exec(value)?.[0] ?? '';
+
 const ShareTargetPage = () => {
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
 
     useEffect(() => {
-        const url = searchParams.get('url') ?? '';
+        const rawUrl = searchParams.get('url') ?? '';
+        const text = searchParams.get('text') ?? '';
         const title = searchParams.get('title') ?? '';
+        const url = rawUrl || extractUrl(text) || extractUrl(title);
+
         const params = new URLSearchParams();
         if (url) params.set('sharedUrl', url);
         if (title) params.set('sharedTitle', title);

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }) => {
                         params: {
                             url: 'url',
                             title: 'title',
+                            text: 'text',
                         },
                     },
                     icons: [


### PR DESCRIPTION
Android's share sheet has no dedicated URL slot, so browsers (Firefox
included) put the shared link in the `text` extra and occasionally
`title` instead — `url` is reliably empty. Our share_target manifest
only declared `url`/`title`, so Chrome's WebAPK translation dropped the
link entirely and RecipesPage never opened the Create Recipe drawer.

Declare `text` in the manifest and fall back to extracting a URL from
`text`/`title` on the share-target route.