### PR TITLE
fix(recipe-import): recover JSON-LD with raw control chars in strings

### DIFF
--- a/packages/api/src/domain/RecipeImportService/index.test.ts
+++ b/packages/api/src/domain/RecipeImportService/index.test.ts
@@ -153,6 +153,29 @@ describe('RecipeImportService', () => {
             expect(result.image).toBe('https://img/first.jpg');
             expect(result.instructions).toEqual(['Line one', 'Line two']);
         });
+
+        it('recovers a Recipe node whose JSON-LD has raw newlines inside string values', async () => {
+            // Some sites (e.g. Shopify recipe apps) emit unescaped control characters
+            // inside JSON-LD string literals, which JSON.parse rejects outright.
+            fetcher.html = `<!doctype html><html><head><script type="application/ld+json">
+                {
+                    "@type": "Recipe",
+                    "name": "Lasagna",
+                    "recipeIngredient": ["2 sticks celery", "1 large carrot"],
+                    "recipeInstructions": [
+                        { "@type": "HowToStep", "text": "Finely dice the celery, carrot and onion, then finely grate the\n     garlic." }
+                    ]
+                }
+            </script></head><body></body></html>`;
+
+            const result = await service.importFromUrl('https://example.com/lasagna');
+
+            expect(result.title).toBe('Lasagna');
+            expect(result.ingredients.map((i) => i.name)).toEqual(['celery', 'carrot']);
+            expect(result.instructions).toEqual([
+                'Finely dice the celery, carrot and onion, then finely grate the garlic.',
+            ]);
+        });
     });
 
     describe('ingredient quantity/unit parsing', () => {
@@ -444,6 +467,27 @@ describe('RecipeImportService', () => {
             await llmService().importFromUrl('https://example.com/c');
 
             expect(parser.calls[0]).toContain('Some recipe prose here.');
+        });
+
+        it('still sends the JSON-LD recipe node when it has raw newlines inside string values', async () => {
+            fetcher.html = `<!doctype html><html><head><script type="application/ld+json">
+                {
+                    "@type": "Recipe",
+                    "name": "Lasagna",
+                    "recipeIngredient": ["2 sticks celery"],
+                    "recipeInstructions": [
+                        { "@type": "HowToStep", "text": "Finely dice the celery, then finely grate the\n     garlic." }
+                    ]
+                }
+            </script></head><body></body></html>`;
+            parser.result = { title: 'Lasagna', ingredients: [{ name: 'celery' }], instructions: ['Dice.'] };
+
+            await llmService().importFromUrl('https://example.com/lasagna');
+
+            // Proves the JSON-LD node was recovered and serialized, not the htmlToText
+            // fallback (which strips <script> tags and would never contain this key).
+            expect(parser.calls[0]).toContain('recipeIngredient');
+            expect(parser.calls[0]).toContain('2 sticks celery');
         });
 
         it('keeps image and timing metadata scraped from the page', async () => {

--- a/packages/api/src/domain/RecipeImportService/index.ts
+++ b/packages/api/src/domain/RecipeImportService/index.ts
@@ -133,12 +133,8 @@ export class RecipeImportService {
             const raw = $(block).text();
             if (!raw.trim()) continue;
 
-            let parsed: unknown;
-            try {
-                parsed = JSON.parse(raw);
-            } catch {
-                continue;
-            }
+            const parsed = this.parseJsonLoosely(raw);
+            if (parsed === undefined) continue;
 
             const node = this.findRecipeNode(parsed);
             if (node) {
@@ -194,12 +190,8 @@ export class RecipeImportService {
             const raw = $(block).text();
             if (!raw.trim()) continue;
 
-            let parsed: unknown;
-            try {
-                parsed = JSON.parse(raw);
-            } catch {
-                continue;
-            }
+            const parsed = this.parseJsonLoosely(raw);
+            if (parsed === undefined) continue;
 
             const recipe = this.findRecipeNode(parsed);
             if (recipe) {
@@ -207,6 +199,58 @@ export class RecipeImportService {
             }
         }
         return {};
+    }
+
+    // Some sites (e.g. Shopify recipe apps) emit JSON-LD with raw, unescaped control
+    // characters — usually literal newlines — inside string values, which is invalid
+    // JSON. A strict JSON.parse throws on the whole block, silently discarding an
+    // otherwise-complete recipe and falling through to much cruder extraction tiers.
+    // Retry with control characters escaped only where they appear inside a string.
+    private parseJsonLoosely(raw: string): unknown {
+        try {
+            return JSON.parse(raw);
+        } catch {
+            try {
+                return JSON.parse(this.sanitizeJsonControlChars(raw));
+            } catch {
+                return undefined;
+            }
+        }
+    }
+
+    private sanitizeJsonControlChars(raw: string): string {
+        let out = '';
+        let inString = false;
+        let escaped = false;
+
+        for (const ch of raw) {
+            if (!inString) {
+                if (ch === '"') inString = true;
+                out += ch;
+                continue;
+            }
+
+            const code = ch.charCodeAt(0);
+            if (escaped) {
+                out += ch;
+                escaped = false;
+            } else if (ch === '\\') {
+                out += ch;
+                escaped = true;
+            } else if (ch === '"') {
+                inString = false;
+                out += ch;
+            } else if (code < 0x20) {
+                if (ch === '\n') out += '\\n';
+                else if (ch === '\r') out += '\\r';
+                else if (ch === '\t') out += '\\t';
+                else out += `\\u${code.toString(16).padStart(4, '0')}`;
+            } else {
+                out += ch;
+            }
+        }
+
+        return out;
     }
 
     // JSON-LD may be a single object, an array of nodes, or wrap nodes in a top-level @graph.


### PR DESCRIPTION
## Summary
- Some sites (e.g. Andy Cooks' Shopify recipe app — reported via `https://www.andy-cooks.com/blogs/recipes/lasagne`) emit JSON-LD `Recipe` blocks with literal, unescaped control characters (usually newlines) inside string values, which is invalid JSON.
- `JSON.parse` threw on the whole block, and the code silently moved on — treating the page as if it had no structured recipe data at all and falling through to the much cruder HTML class-name heuristics tier. That's why importing that URL produced a different, less accurate ingredient list than what's actually in the page's own JSON-LD.
- The same strict-parse pattern is duplicated in the LLM-first path's JSON-LD lookup (`llmSource`), so it would silently fall back to raw page text instead of feeding the LLM the clean, structured recipe node.
- Added a shared retry (`parseJsonLoosely` / `sanitizeJsonControlChars`) that escapes control characters only where they occur inside a JSON string literal — leaving well-formed JSON-LD (the vast majority of sites) completely untouched — and wired it into both call sites.

## Test plan
- [x] Downloaded the real `andy-cooks.com` lasagne page and ran the import service against it directly: recovers the full, correct 22-ingredient list (`2 sticks celery`, `1 large carrot`, `4 cloves garlic`, ... `600ml milk`) straight from the page's JSON-LD, instead of falling back to Tier 2
- [x] Added a regression test reproducing the exact bug (raw newline inside a JSON-LD string) for both the standard tiered path and the LLM-first path
- [x] `bun run --filter @shoppingo/api test` — 514 pass, 0 fail
- [x] `bun run lint` — clean (same 3 pre-existing warnings, unrelated to this change)
- [x] `bun run --filter @shoppingo/api build` — succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01FYbTq3kUHwkQwXAqsRV6xH)_