### PR TITLE
fix(web): toolbar/nav polish, add-friend rework, and recipe search/sharing fixes

### DIFF
--- a/packages/web/src/api/index.ts
+++ b/packages/web/src/api/index.ts
@@ -305,6 +305,23 @@ export const deleteRecipe = async (recipeId: string): Promise<void> => {
     });
 };
 
+export const addUserToRecipe = async (recipeId: string, friendId: string): Promise<Recipe> => {
+    return await makeRequest({
+        pathname: `/api/recipes/${encodeURIComponent(recipeId)}/users`,
+        method: MethodType.POST,
+        operationString: 'add user to recipe',
+        body: JSON.stringify({ friendId }),
+    });
+};
+
+export const removeUserFromRecipe = async (recipeId: string, userId: string): Promise<Recipe> => {
+    return await makeRequest({
+        pathname: `/api/recipes/${encodeURIComponent(recipeId)}/users/${encodeURIComponent(userId)}`,
+        method: MethodType.DELETE,
+        operationString: 'remove user from recipe',
+    });
+};
+
 export const generateRecipeAiImage = async (recipeId: string): Promise<Recipe> => {
     return await makeRequest({
         pathname: `/api/recipes/${encodeURIComponent(recipeId)}/image/generate`,

--- a/packages/web/src/components/ManageUsersDrawer/index.test.tsx
+++ b/packages/web/src/components/ManageUsersDrawer/index.test.tsx
@@ -13,13 +13,6 @@ vi.mock('../../hooks/useFriends', () => ({
     useFriends: mockUseFriends,
 }));
 
-vi.mock('../../hooks/useManageUsers', () => ({
-    useManageUsers: () => ({
-        addUserMutation: { isLoading: false, mutate: mockAddMutate },
-        removeUserMutation: { isLoading: false, mutate: mockRemoveMutate },
-    }),
-}));
-
 describe('ManageUsersDrawer', () => {
     const mockOnOpenChange = vi.fn();
     const mockOnUserAdded = vi.fn();
@@ -28,13 +21,15 @@ describe('ManageUsersDrawer', () => {
     const defaultProps = {
         open: true,
         onOpenChange: mockOnOpenChange,
-        listTitle: 'Shopping List',
+        title: 'Shopping List',
         currentUsers: [
             { id: 'owner-1', username: 'john' },
             { id: 'friend-1', username: 'alice' },
         ],
         ownerId: 'owner-1',
         currentUserId: 'owner-1',
+        addUserMutation: { isLoading: false, mutate: mockAddMutate },
+        removeUserMutation: { isLoading: false, mutate: mockRemoveMutate },
         onUserAdded: mockOnUserAdded,
         onUserRemoved: mockOnUserRemoved,
     };

--- a/packages/web/src/components/ManageUsersDrawer/index.tsx
+++ b/packages/web/src/components/ManageUsersDrawer/index.tsx
@@ -24,16 +24,21 @@ import {
 import { Label } from '../../components/ui/label';
 import { useConfirmation } from '../../hooks/useConfirmation';
 import { useFriends } from '../../hooks/useFriends';
-import { useManageUsers } from '../../hooks/useManageUsers';
 import { FriendPicker } from '../FriendPicker';
+
+interface MutationLike<TVariables> {
+    mutate: (variables: TVariables, options?: { onSuccess?: () => void }) => void;
+}
 
 interface ManageUsersDrawerProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    listTitle: string;
+    title: string;
     currentUsers: Array<{ id: string; username: string }>;
     ownerId: string;
     currentUserId: string;
+    addUserMutation: MutationLike<string>;
+    removeUserMutation: MutationLike<string>;
     onUserAdded: () => void;
     onUserRemoved: () => void;
 }
@@ -44,13 +49,14 @@ const getMemberIds = (currentUsers: Array<{ id: string; username: string }>, own
 export const ManageUsersDrawer = ({
     open,
     onOpenChange,
-    listTitle,
+    title,
     currentUsers,
     ownerId,
+    addUserMutation,
+    removeUserMutation,
     onUserAdded,
     onUserRemoved,
 }: ManageUsersDrawerProps) => {
-    const { addUserMutation, removeUserMutation } = useManageUsers({ listTitle });
     const { friends } = useFriends();
     const { confirm, isOpen, config: confirmConfig, handleConfirm, handleCancel } = useConfirmation();
 
@@ -102,7 +108,7 @@ export const ManageUsersDrawer = ({
                     <div className="mx-auto w-full max-w-sm flex flex-col h-[500px] max-h-[500px]">
                         <DrawerHeader className="flex-shrink-0">
                             <DrawerTitle>Manage Users</DrawerTitle>
-                            <DrawerDescription>{listTitle}</DrawerDescription>
+                            <DrawerDescription>{title}</DrawerDescription>
                         </DrawerHeader>
 
                         <div className="flex-1 overflow-y-auto p-4">

--- a/packages/web/src/components/ToolBar/index.test.tsx
+++ b/packages/web/src/components/ToolBar/index.test.tsx
@@ -33,6 +33,13 @@ vi.mock('../../hooks/useToolBarState', () => ({
     useToolBarState: mockUseToolBarState,
 }));
 
+vi.mock('../../hooks/useManageUsers', () => ({
+    useManageUsers: () => ({
+        addUserMutation: { isLoading: false, mutate: vi.fn() },
+        removeUserMutation: { isLoading: false, mutate: vi.fn() },
+    }),
+}));
+
 vi.mock('./HamburgerMenu', () => ({
     HamburgerMenu: () => <div data-testid="hamburger-menu">Menu</div>,
 }));

--- a/packages/web/src/components/ToolBar/index.tsx
+++ b/packages/web/src/components/ToolBar/index.tsx
@@ -10,6 +10,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import useMeasure from 'react-use-measure';
 
 import { Card } from '../../components/ui/card';
+import { useManageUsers } from '../../hooks/useManageUsers';
 import { useToolBarState } from '../../hooks/useToolBarState';
 import { ManageLabelsDrawer } from '../ManageLabelsDrawer';
 import { ManageUsersDrawer } from '../ManageUsersDrawer';
@@ -45,6 +46,7 @@ interface ToolBarProps {
     addRecipeInitialLink?: string;
     addRecipeAutoImport?: boolean;
     handleGoBack?: () => void;
+    onManageRecipeUsers?: () => void;
     handleClearSelected?: () => void;
     handleRemoveAll?: () => void;
     onToggleSelectMode?: () => void;
@@ -71,6 +73,7 @@ const ToolBar = ({
     addRecipeInitialLink,
     addRecipeAutoImport,
     handleGoBack,
+    onManageRecipeUsers,
     handleClearSelected,
     handleRemoveAll,
     onToggleSelectMode,
@@ -122,6 +125,10 @@ const ToolBar = ({
 
     const isOwner = !!(currentList && currentList.ownerId === userId);
 
+    const { addUserMutation: addListUserMutation, removeUserMutation: removeListUserMutation } = useManageUsers({
+        listTitle: currentList?.title ?? '',
+    });
+
     const actionItems: ActionItem[] = [
         {
             show: isItemsPage && !!currentList && !!listItems && currentListType === ListType.SHOPPING,
@@ -155,6 +162,12 @@ const ToolBar = ({
             label: 'Add to Shopping List',
             icon: ShoppingCart,
             onClick: () => onToggleSelectMode?.(),
+        },
+        {
+            show: isRecipeDetailPage && !!onManageRecipeUsers,
+            label: 'Manage Sharing',
+            icon: Users,
+            onClick: () => onManageRecipeUsers?.(),
         },
         {
             show: isCalendarPage,
@@ -349,10 +362,12 @@ const ToolBar = ({
                 <ManageUsersDrawer
                     open={isManageUsersOpen}
                     onOpenChange={setIsManageUsersOpen}
-                    listTitle={currentList.title}
+                    title={currentList.title}
                     currentUsers={currentList.users}
                     ownerId={currentList.ownerId ?? ''}
                     currentUserId={userId ?? ''}
+                    addUserMutation={addListUserMutation}
+                    removeUserMutation={removeListUserMutation}
                     onUserAdded={() => {
                         refetchList?.();
                     }}

--- a/packages/web/src/hooks/useManageRecipeUsers.ts
+++ b/packages/web/src/hooks/useManageRecipeUsers.ts
@@ -1,0 +1,60 @@
+import { useMutation } from 'react-query';
+import { toast } from 'sonner';
+import { addUserToRecipe, removeUserFromRecipe } from '../api';
+
+interface ManageRecipeUsersHookProps {
+    recipeId: string;
+}
+
+export const useManageRecipeUsers = ({ recipeId }: ManageRecipeUsersHookProps) => {
+    const addUserMutation = useMutation({
+        mutationFn: (friendId: string) => addUserToRecipe(recipeId, friendId),
+        onSuccess: () => {
+            toast.success('User added successfully', {
+                style: {
+                    backgroundColor: '#10b981',
+                    color: '#ffffff',
+                    border: 'none',
+                },
+            });
+        },
+        onError: (error: unknown) => {
+            const err = error as { message?: string };
+            toast.error(err.message || 'Failed to add user', {
+                style: {
+                    backgroundColor: '#ef4444',
+                    color: '#ffffff',
+                    border: 'none',
+                },
+            });
+        },
+    });
+
+    const removeUserMutation = useMutation({
+        mutationFn: (userId: string) => removeUserFromRecipe(recipeId, userId),
+        onSuccess: () => {
+            toast.success('User removed successfully', {
+                style: {
+                    backgroundColor: '#10b981',
+                    color: '#ffffff',
+                    border: 'none',
+                },
+            });
+        },
+        onError: (error: unknown) => {
+            const err = error as { message?: string };
+            toast.error(err.message || 'Failed to remove user', {
+                style: {
+                    backgroundColor: '#ef4444',
+                    color: '#ffffff',
+                    border: 'none',
+                },
+            });
+        },
+    });
+
+    return {
+        addUserMutation,
+        removeUserMutation,
+    };
+};

--- a/packages/web/src/pages/RecipeDetailPage/index.tsx
+++ b/packages/web/src/pages/RecipeDetailPage/index.tsx
@@ -8,6 +8,7 @@ import { useQuery, useQueryClient } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { addItemsBulk, getListsQuery, getRecipeQuery } from '../../api';
+import { ManageUsersDrawer } from '../../components/ManageUsersDrawer';
 import ToolBar from '../../components/ToolBar';
 import {
     AlertDialog,
@@ -23,6 +24,7 @@ import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Skeleton } from '../../components/ui/skeleton';
 import { useConfirmation } from '../../hooks/useConfirmation';
+import { useManageRecipeUsers } from '../../hooks/useManageRecipeUsers';
 import { useRecipeMutations } from '../../hooks/useRecipeMutations';
 import { logger } from '../../utils/logger';
 import { CoverImageSection } from './CoverImageSection';
@@ -38,12 +40,14 @@ const RecipeDetailPage = () => {
     const queryClient = useQueryClient();
     const { updateRecipe, deleteRecipe } = useRecipeMutations(user ?? undefined);
     const { confirm, isOpen, config: confirmConfig, handleConfirm, handleCancel } = useConfirmation();
+    const { addUserMutation, removeUserMutation } = useManageRecipeUsers({ recipeId: recipeId ?? '' });
 
     const [isEditingTitle, setIsEditingTitle] = useState(false);
     const [editedTitle, setEditedTitle] = useState('');
     const [isSelectMode, setIsSelectMode] = useState(false);
     const [isEditingLink, setIsEditingLink] = useState(false);
     const [editedLink, setEditedLink] = useState('');
+    const [isManageUsersOpen, setIsManageUsersOpen] = useState(false);
 
     const {
         data: recipe,
@@ -429,7 +433,23 @@ const RecipeDetailPage = () => {
                 onAddIngredient={isOwner ? handleAddIngredient : undefined}
                 handleGoBack={handleGoBack}
                 onToggleSelectMode={() => setIsSelectMode((v) => !v)}
+                onManageRecipeUsers={isOwner ? () => setIsManageUsersOpen(true) : undefined}
             />
+
+            {recipe && isOwner && (
+                <ManageUsersDrawer
+                    open={isManageUsersOpen}
+                    onOpenChange={setIsManageUsersOpen}
+                    title={recipe.title}
+                    currentUsers={recipe.users}
+                    ownerId={recipe.ownerId ?? ''}
+                    currentUserId={user?.id ?? ''}
+                    addUserMutation={addUserMutation}
+                    removeUserMutation={removeUserMutation}
+                    onUserAdded={() => void refetch()}
+                    onUserRemoved={() => void refetch()}
+                />
+            )}
 
             <AlertDialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
                 <AlertDialogContent>

--- a/packages/web/src/pages/RecipesPage/index.tsx
+++ b/packages/web/src/pages/RecipesPage/index.tsx
@@ -136,7 +136,7 @@ const RecipesPage = () => {
     };
 
     const searchBar = (
-        <div className="relative mb-6">
+        <div className="relative mt-6">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             <Input
                 value={searchQuery}
@@ -159,7 +159,6 @@ const RecipesPage = () => {
 
     const pageContent = (
         <div className="flex flex-col mb-auto">
-            {searchBar}
             {searchQuery.trim() ? (
                 <div>
                     <h2 className="text-lg font-semibold mb-3 text-foreground">Results ({searchResults.length})</h2>
@@ -218,6 +217,7 @@ const RecipesPage = () => {
                     </div>
                 </div>
             )}
+            {searchBar}
         </div>
     );
 


### PR DESCRIPTION
## Summary
- Continuation of the mobile toolbar rework: static Lists/Recipes/Friends/Calendar/Menu nav row with an `ActionsFab` for per-page actions, equal-spaced/flattened nav row, back button correctly swaps in per drill-in page (Items → `/`, Recipe detail → `/recipes`) instead of always going to shopping lists.
- `AddFriendDrawer` split into smaller panels and polished for mobile.
- Fixed a crash: optimistic list-cache updates threw when a cached list's `items` field was missing.
- Recipe search input moved to the bottom of the Recipes page (was above the Your/Shared Recipes sections).
- Recipe owners can now manage sharing after creation: the API already exposed `addUserToRecipe`/`removeUserFromRecipe` but nothing on the frontend called them — added the API client functions, a `useManageRecipeUsers` hook, generalized `ManageUsersDrawer` to take mutation props (works for both lists and recipes now), and wired a "Manage Sharing" action into the recipe detail page's ToolBar for owners.
- Assorted e2e fixes to match the reworked toolbar (routed toolbar actions through `ActionsFab`, updated friend-drawer copy/labels, tightened global timeout).

## Test plan
- [x] `bun run lint:fix`
- [x] `bun run tsc --noEmit`
- [x] `bun run --filter @shoppingo/web test` (391 passing)
- [x] `bun run --filter @shoppingo/web build`
- [ ] Manual pass in-browser for recipe search placement + manage-sharing drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)