### PR TITLE
feat(e2e): add kanban-worker repo config and a real @smoke-tagged test

### DIFF
--- a/.kanban-cli.json
+++ b/.kanban-cli.json
@@ -1,0 +1,29 @@
+{
+  "repoName": "shoppingo",
+  "dev": {
+    "startCommand": "bun run start:web",
+    "healthCheckUrl": "http://localhost:4000",
+    "healthCheckTimeoutMs": 60000,
+    "healthCheckIntervalMs": 2000
+  },
+  "e2e": {
+    "testCommand": "bun run test:e2e",
+    "smokeGrep": "@smoke",
+    "configPath": "playwright.config.ts"
+  },
+  "ci": {
+    "workflowNames": ["PR"],
+    "checkNamesRequired": ["lint", "test", "e2e", "fallow-deadcode"]
+  },
+  "deploy": {
+    "workflowName": "CD",
+    "timeoutMs": 900000,
+    "pollIntervalMs": 15000
+  },
+  "environments": {
+    "production": { "baseUrl": "https://shoppingo.imapps.uk" }
+  },
+  "targetEnvironment": "production",
+  "retryPolicy": { "implement": 3, "e2e_local": 3, "ci": 3, "deploy": 2, "e2e_live": 1 },
+  "github": { "defaultBranch": "main", "mergeMethod": "squash" }
+}

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test';
+
+// Read-only, no auth/mocking required — safe to run against any deployed
+// environment (including production) as a post-deploy sanity check that the
+// correct build actually shipped and is serving traffic.
+test('deployed build serves the login page @smoke', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByText('Login to your account', { exact: true })).toBeVisible();
+});


### PR DESCRIPTION
Adds .kanban-cli.json so kanban-worker can drive this repo's board items, and a minimal @smoke-tagged e2e spec (unauthenticated, read-only login-page check) so the post-deploy live-check gate matches at least one real test instead of failing with "No tests found" on every run.