### PR TITLE
fix(web): include shared friends in optimistic recipe.create cache

### DIFF
--- a/packages/web/src/hooks/useManageRecipeUsers.test.tsx
+++ b/packages/web/src/hooks/useManageRecipeUsers.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAddUserToRecipe, mockRemoveUserFromRecipe } = vi.hoisted(() => ({
+    mockAddUserToRecipe: vi.fn(),
+    mockRemoveUserFromRecipe: vi.fn(),
+}));
+
+vi.mock('../api', () => ({
+    addUserToRecipe: mockAddUserToRecipe,
+    removeUserFromRecipe: mockRemoveUserFromRecipe,
+}));
+
+import { useManageRecipeUsers } from './useManageRecipeUsers';
+
+const wrap =
+    (client: QueryClient) =>
+    ({ children }: { children: ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+
+describe('useManageRecipeUsers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('invalidates the recipes list cache after a user is added', async () => {
+        mockAddUserToRecipe.mockResolvedValue({ id: 'R1', users: [] });
+        const client = new QueryClient();
+        const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+        const { result } = renderHook(() => useManageRecipeUsers({ recipeId: 'R1', userId: 'user-1' }), {
+            wrapper: wrap(client),
+        });
+
+        result.current.addUserMutation.mutate('friend-1');
+
+        await waitFor(() => expect(mockAddUserToRecipe).toHaveBeenCalledWith('R1', 'friend-1'));
+        await waitFor(() => expect(invalidateSpy).toHaveBeenCalledWith(['recipes', 'user-1']));
+    });
+
+    it('invalidates the recipes list cache after a user is removed', async () => {
+        mockRemoveUserFromRecipe.mockResolvedValue({ id: 'R1', users: [] });
+        const client = new QueryClient();
+        const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+        const { result } = renderHook(() => useManageRecipeUsers({ recipeId: 'R1', userId: 'user-1' }), {
+            wrapper: wrap(client),
+        });
+
+        result.current.removeUserMutation.mutate('friend-1');
+
+        await waitFor(() => expect(mockRemoveUserFromRecipe).toHaveBeenCalledWith('R1', 'friend-1'));
+        await waitFor(() => expect(invalidateSpy).toHaveBeenCalledWith(['recipes', 'user-1']));
+    });
+});

--- a/packages/web/src/hooks/useManageRecipeUsers.ts
+++ b/packages/web/src/hooks/useManageRecipeUsers.ts
@@ -1,15 +1,23 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { toast } from 'sonner';
 import { addUserToRecipe, removeUserFromRecipe } from '../api';
 
 interface ManageRecipeUsersHookProps {
     recipeId: string;
+    userId: string;
 }
 
-export const useManageRecipeUsers = ({ recipeId }: ManageRecipeUsersHookProps) => {
+export const useManageRecipeUsers = ({ recipeId, userId }: ManageRecipeUsersHookProps) => {
+    const queryClient = useQueryClient();
+
+    const invalidateRecipesList = () => {
+        if (userId) void queryClient.invalidateQueries(['recipes', userId]);
+    };
+
     const addUserMutation = useMutation({
         mutationFn: (friendId: string) => addUserToRecipe(recipeId, friendId),
         onSuccess: () => {
+            invalidateRecipesList();
             toast.success('User added successfully', {
                 style: {
                     backgroundColor: '#10b981',
@@ -33,6 +41,7 @@ export const useManageRecipeUsers = ({ recipeId }: ManageRecipeUsersHookProps) =
     const removeUserMutation = useMutation({
         mutationFn: (userId: string) => removeUserFromRecipe(recipeId, userId),
         onSuccess: () => {
+            invalidateRecipesList();
             toast.success('User removed successfully', {
                 style: {
                     backgroundColor: '#10b981',

--- a/packages/web/src/hooks/useRecipeMutations.test.tsx
+++ b/packages/web/src/hooks/useRecipeMutations.test.tsx
@@ -5,6 +5,12 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../offline/drainer', () => ({ drainOutbox: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./useFriends', () => ({
+    useFriends: () => ({
+        friends: [{ id: 'friend-1', username: 'alice' }],
+        isLoading: false,
+    }),
+}));
 
 import { outboxStore } from '../offline/outboxStore';
 import { useRecipeMutations } from './useRecipeMutations';
@@ -30,6 +36,22 @@ describe('useRecipeMutations', () => {
         expect(outboxStore.peekAll()[0]).toMatchObject({ op: 'recipe.create', entityType: 'recipe', scope: 'user-1' });
         const cached = client.getQueryData(['recipes', 'user-1']) as Array<{ title: string }>;
         expect(cached.map((r) => r.title)).toContain('Pasta');
+    });
+
+    it('createRecipe includes selected friends in the optimistic users list', async () => {
+        const client = new QueryClient();
+        client.setQueryData(['recipes', 'user-1'], []);
+        const { result } = renderHook(() => useRecipeMutations(user), { wrapper: wrap(client) });
+        await act(async () => {
+            await result.current.createRecipe('Pasta', ['friend-1'], []);
+        });
+        await waitFor(() => expect(outboxStore.peekAll()).toHaveLength(1));
+        const cached = client.getQueryData(['recipes', 'user-1']) as Array<{
+            title: string;
+            users: Array<{ id: string }>;
+        }>;
+        const created = cached.find((r) => r.title === 'Pasta');
+        expect(created?.users.map((u) => u.id).sort()).toEqual(['friend-1', 'user-1']);
     });
 
     it('deleteRecipe enqueues a recipe.delete intent', async () => {

--- a/packages/web/src/hooks/useRecipeMutations.ts
+++ b/packages/web/src/hooks/useRecipeMutations.ts
@@ -3,9 +3,11 @@ import { useQueryClient } from 'react-query';
 import { drainOutbox } from '../offline/drainer';
 import { applyRecipeIntent } from '../offline/intents';
 import { type OutboxIntent, outboxStore } from '../offline/outboxStore';
+import { useFriends } from './useFriends';
 
 export const useRecipeMutations = (user: User | undefined) => {
     const queryClient = useQueryClient();
+    const { friends } = useFriends();
     const userId = user?.id ?? '';
 
     const enqueueRecipe = async (op: OutboxIntent['op'], targetId: string, payload: Record<string, unknown>) => {
@@ -39,6 +41,7 @@ export const useRecipeMutations = (user: User | undefined) => {
             instructions?: string[]
         ): Promise<string> => {
             const id = crypto.randomUUID();
+            const sharedFriends = friends.filter((f) => selectedUsers.includes(f.id));
             await enqueueRecipe('recipe.create', id, {
                 title,
                 selectedUsers,
@@ -46,7 +49,7 @@ export const useRecipeMutations = (user: User | undefined) => {
                 link,
                 instructions,
                 user,
-                users: user ? [user] : [],
+                users: user ? [user, ...sharedFriends] : sharedFriends,
                 ownerId: userId,
             });
             return id;

--- a/packages/web/src/pages/RecipeDetailPage/index.tsx
+++ b/packages/web/src/pages/RecipeDetailPage/index.tsx
@@ -42,7 +42,10 @@ const RecipeDetailPage = () => {
     const queryClient = useQueryClient();
     const { updateRecipe, deleteRecipe } = useRecipeMutations(user ?? undefined);
     const { confirm, isOpen, config: confirmConfig, handleConfirm, handleCancel } = useConfirmation();
-    const { addUserMutation, removeUserMutation } = useManageRecipeUsers({ recipeId: recipeId ?? '' });
+    const { addUserMutation, removeUserMutation } = useManageRecipeUsers({
+        recipeId: recipeId ?? '',
+        userId: user?.id ?? '',
+    });
 
     const [isEditingTitle, setIsEditingTitle] = useState(false);
     const [editedTitle, setEditedTitle] = useState('');


### PR DESCRIPTION
Fixes recipes showing "none shared" immediately after creation. `useRecipeMutations.createRecipe`'s optimistic outbox payload built `users` from the owner only, dropping `selectedUsers` — the UI showed zero shared users until the outbox intent drained and a server refetch overwrote the stale cache entry (backend was always correct). Also makes `useManageRecipeUsers`'s add/remove mutations invalidate the recipes-list query cache, matching the existing `useUnfriend` pattern, instead of relying on incidental remounts.

Covered by two new/extended unit tests (verified fail-before-fix, pass-after) in useRecipeMutations.test.tsx and the new useManageRecipeUsers.test.tsx. No new e2e coverage: this specific race (optimistic cache vs. outbox drain) only manifests under real network latency — the backend already resolves selectedUsers independently on creation, so a fast local e2e run drains the outbox before any assertion could observe the bug, making an e2e test here pass regardless of the fix (verified this empirically before deciding not to ship a decorative test).