### PR TITLE
fix(web): stop payment-autofill popup on recipe search inputs

### DIFF
--- a/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.test.tsx
+++ b/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.test.tsx
@@ -25,4 +25,14 @@ describe('AddFromRecipeDrawer', () => {
         );
         expect(screen.queryByLabelText('Add from recipe')).not.toBeInTheDocument();
     });
+
+    it('renders the recipe search input with autofill-safe attributes', () => {
+        render(<AddFromRecipeDrawer open onOpenChange={noop} listTitle="Groceries" listItems={[]} />);
+
+        const searchInput = screen.getByPlaceholderText('Search recipes...');
+        expect(searchInput).toHaveAttribute('autocomplete', 'off');
+        expect(searchInput).toHaveAttribute('name', 'add-from-recipe-search');
+        expect(searchInput).toHaveAttribute('inputmode', 'search');
+        expect(searchInput).not.toHaveAttribute('type', 'search');
+    });
 });

--- a/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.tsx
+++ b/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.tsx
@@ -153,6 +153,9 @@ export const AddFromRecipeDrawer = ({
                                         onChange={(e) => setRecipeSearch(e.target.value)}
                                         placeholder="Search recipes..."
                                         className="pl-9 pr-9"
+                                        name="add-from-recipe-search"
+                                        autoComplete="off"
+                                        inputMode="search"
                                     />
                                     {recipeSearch && (
                                         <button

--- a/packages/web/src/pages/RecipesPage/index.test.tsx
+++ b/packages/web/src/pages/RecipesPage/index.test.tsx
@@ -1,10 +1,16 @@
 import type { Recipe } from '@shoppingo/types';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RecipesPage from './index';
 
 // Mock dependencies
 vi.mock('../../api', () => ({
-    getRecipesQuery: vi.fn(),
+    getRecipesQuery: vi.fn(() => ({ queryKey: ['recipes', 'user-1'], queryFn: vi.fn() })),
+    getFriendsQuery: vi.fn(() => ({ queryKey: ['friends'], queryFn: vi.fn() })),
     addRecipe: vi.fn(),
+    generateRecipeAiImage: vi.fn(),
+    uploadRecipeImage: vi.fn(),
 }));
 
 vi.mock('@imapps/web-utils', () => ({
@@ -14,10 +20,28 @@ vi.mock('@imapps/web-utils', () => ({
             username: 'testuser',
         },
     }),
+    useAuth: () => ({ logout: vi.fn() }),
 }));
 
 vi.mock('react-query', () => ({
-    useQuery: vi.fn(),
+    useQuery: () => ({
+        data: [] as Recipe[],
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+    }),
+    useQueryClient: () => ({
+        getQueryData: vi.fn(() => []),
+        invalidateQueries: vi.fn(),
+    }),
+}));
+
+vi.mock('../../contexts/PullToRefreshContext', () => ({
+    usePullToRefreshContext: () => ({ registerRefresh: () => () => {} }),
+}));
+
+vi.mock('../../components/ToolBar', () => ({
+    default: () => <div data-testid="toolbar" />,
 }));
 
 describe('RecipesPage', () => {
@@ -40,10 +64,18 @@ describe('RecipesPage', () => {
         vi.clearAllMocks();
     });
 
-    it('displays your recipes and shared recipes sections', () => {
-        // This test would need proper query mocking setup
-        // Simplified version shown here
-        expect(true).toBe(true);
+    it('renders the recipe search input with autofill-safe attributes', () => {
+        render(
+            <MemoryRouter>
+                <RecipesPage />
+            </MemoryRouter>
+        );
+
+        const searchInput = screen.getByPlaceholderText('Search recipes...');
+        expect(searchInput).toHaveAttribute('autocomplete', 'off');
+        expect(searchInput).toHaveAttribute('name', 'recipe-search');
+        expect(searchInput).toHaveAttribute('inputmode', 'search');
+        expect(searchInput).not.toHaveAttribute('type', 'search');
     });
 
     it('passes refetch function to ToolBar for recipe updates', async () => {

--- a/packages/web/src/pages/RecipesPage/index.tsx
+++ b/packages/web/src/pages/RecipesPage/index.tsx
@@ -143,6 +143,9 @@ const RecipesPage = () => {
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search recipes..."
                 className="pl-9 pr-9"
+                name="recipe-search"
+                autoComplete="off"
+                inputMode="search"
             />
             {searchQuery && (
                 <button


### PR DESCRIPTION
Adds explicit autoComplete="off", a non-card-like `name`, and inputMode="search" to both recipe-search inputs (RecipesPage and the Add-from-recipe drawer) so mobile browsers stop matching them against saved payment methods. Pure attribute fix, type="text" unchanged (avoids a native search-input clear-button regression on top of the existing custom one). Regression tests added in both components' test files.

Closes shoppingo-recipe-search-autofill-popups board item.