### PR TITLE
fix(web): stop pull-to-refresh false-triggering while scrolling recipes

### DIFF
--- a/packages/web/src/components/Layout/index.test.tsx
+++ b/packages/web/src/components/Layout/index.test.tsx
@@ -1,13 +1,20 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { PullToRefreshProvider } from '../../contexts/PullToRefreshContext';
 import { Layout } from './index';
 
-const renderWithProvider = (ui: React.ReactElement) => render(<PullToRefreshProvider>{ui}</PullToRefreshProvider>);
+const renderAtPath = (path: string, ui: React.ReactElement) =>
+    render(
+        <MemoryRouter initialEntries={[path]}>
+            <PullToRefreshProvider>{ui}</PullToRefreshProvider>
+        </MemoryRouter>
+    );
 
 describe('Layout', () => {
     it('renders children', () => {
-        renderWithProvider(
+        renderAtPath(
+            '/',
             <Layout>
                 <p>Test content</p>
             </Layout>
@@ -17,7 +24,8 @@ describe('Layout', () => {
     });
 
     it('applies fixed positioning styles', () => {
-        const { container } = renderWithProvider(
+        const { container } = renderAtPath(
+            '/',
             <Layout>
                 <p>Content</p>
             </Layout>
@@ -28,7 +36,8 @@ describe('Layout', () => {
     });
 
     it('applies padding and max-width', () => {
-        const { container } = renderWithProvider(
+        const { container } = renderAtPath(
+            '/',
             <Layout>
                 <p>Content</p>
             </Layout>
@@ -38,8 +47,9 @@ describe('Layout', () => {
         expect(layoutDiv).toHaveClass('px-4', 'py-2', 'max-w-[500px]', 'mx-auto');
     });
 
-    it('renders children in reverse flex column', () => {
-        const { container } = renderWithProvider(
+    it('renders children in reverse flex column on bottom-anchored routes', () => {
+        const { container } = renderAtPath(
+            '/',
             <Layout>
                 <p>Content</p>
             </Layout>
@@ -49,5 +59,19 @@ describe('Layout', () => {
         // The scroll container is the last child (after PullToRefreshIndicator)
         const scrollDiv = outerDiv.lastElementChild as HTMLElement;
         expect(scrollDiv).toHaveClass('flex-col-reverse', 'overflow-y-auto', 'h-full', 'overscroll-y-contain');
+    });
+
+    it('renders children in normal (non-reversed) flex column on the recipes route', () => {
+        const { container } = renderAtPath(
+            '/recipes',
+            <Layout>
+                <p>Content</p>
+            </Layout>
+        );
+
+        const outerDiv = container.firstChild as HTMLElement;
+        const scrollDiv = outerDiv.lastElementChild as HTMLElement;
+        expect(scrollDiv).toHaveClass('flex-col', 'overflow-y-auto', 'h-full', 'overscroll-y-contain');
+        expect(scrollDiv).not.toHaveClass('flex-col-reverse');
     });
 });

--- a/packages/web/src/components/Layout/index.tsx
+++ b/packages/web/src/components/Layout/index.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
 import { usePullToRefreshContext } from '../../contexts/PullToRefreshContext';
 import { usePullToRefresh } from '../../hooks/usePullToRefresh';
 import { PullToRefreshIndicator } from '../PullToRefreshIndicator';
@@ -7,14 +8,25 @@ interface LayoutProps {
     children: ReactNode;
 }
 
+// Routes whose content needs normal (top-anchored, non-reversed) scroll semantics.
+// Every other route keeps the default flex-col-reverse (bottom-anchored, chat-like)
+// container. See Layout/index.test.tsx and CalendarPage/index.tsx's own comment for
+// why flex-col-reverse's scrollTop behavior can't be trusted once content overflows:
+// it broke pull-to-refresh's "am I at the top" check on the Recipes page, which has
+// no need for bottom-anchoring in the first place.
+const NORMAL_SCROLL_ROUTES = new Set(['/recipes']);
+
 export const Layout = ({ children }: LayoutProps) => {
     const { executeRefresh } = usePullToRefreshContext();
     const { scrollRef, pullY, isRefreshing, hasTriggered } = usePullToRefresh(executeRefresh);
+    const { pathname } = useLocation();
+
+    const flexDirectionClass = NORMAL_SCROLL_ROUTES.has(pathname) ? 'flex-col' : 'flex-col-reverse';
 
     return (
         <div className="fixed top-14 md:top-16 bottom-24 left-0 right-0 px-4 py-2 max-w-[500px] mx-auto">
             <PullToRefreshIndicator pullY={pullY} isRefreshing={isRefreshing} hasTriggered={hasTriggered} />
-            <div ref={scrollRef} className="h-full overflow-y-auto flex flex-col-reverse overscroll-y-contain">
+            <div ref={scrollRef} className={`h-full overflow-y-auto flex ${flexDirectionClass} overscroll-y-contain`}>
                 {children}
             </div>
         </div>

--- a/packages/web/src/pages/RecipesPage/index.tsx
+++ b/packages/web/src/pages/RecipesPage/index.tsx
@@ -161,7 +161,7 @@ const RecipesPage = () => {
     );
 
     const pageContent = (
-        <div className="flex flex-col mb-auto">
+        <div className="flex flex-col">
             {searchQuery.trim() ? (
                 <div>
                     <h2 className="text-lg font-semibold mb-3 text-foreground">Results ({searchResults.length})</h2>


### PR DESCRIPTION
Layout's shared scroll container uses flex-col-reverse to bottom-anchor chat-like pages (Lists/Items), but that makes scrollTop unreliable once content overflows. RecipesPage never opted out of it (it only patched the visual symptom with mb-auto), so usePullToRefresh's scrollTop<=1 gate was reading a reversed container while scrolling a long recipe grid, arming the pull gesture mid-scroll.

Makes Layout's flex-direction route-aware: normal flex-col (reliable scrollTop) on /recipes, unchanged flex-col-reverse everywhere else. Also removes the now-redundant mb-auto workaround from RecipesPage.

No changes to usePullToRefresh.ts thresholds, CalendarPage, ListsPage, or ItemsPage.