### PR TITLE
fix(web): draw input focus ring inset so it can't be clipped by ancestor overflow

### DIFF
--- a/packages/web/src/components/ui/input.test.tsx
+++ b/packages/web/src/components/ui/input.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Input } from './input';
+
+describe('Input', () => {
+    it('renders an inset focus ring so it cannot be clipped by ancestor overflow', () => {
+        render(<Input placeholder="Search recipes..." />);
+
+        const input = screen.getByPlaceholderText('Search recipes...');
+        expect(input).toHaveClass('focus-visible:ring-inset');
+    });
+
+    it('still merges custom className with the base classes', () => {
+        render(<Input placeholder="Search recipes..." className="pl-9 pr-9" />);
+
+        const input = screen.getByPlaceholderText('Search recipes...');
+        expect(input).toHaveClass('pl-9', 'pr-9', 'focus-visible:ring-inset');
+    });
+});

--- a/packages/web/src/components/ui/input.tsx
+++ b/packages/web/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
         <input
             type={type}
             className={cn(
-                'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+                'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
                 className
             )}
             ref={ref}

--- a/packages/web/src/pages/RecipesPage/index.test.tsx
+++ b/packages/web/src/pages/RecipesPage/index.test.tsx
@@ -78,6 +78,17 @@ describe('RecipesPage', () => {
         expect(searchInput).not.toHaveAttribute('type', 'search');
     });
 
+    it('renders the search input with an inset focus ring', () => {
+        render(
+            <MemoryRouter>
+                <RecipesPage />
+            </MemoryRouter>
+        );
+
+        const searchInput = screen.getByPlaceholderText('Search recipes...');
+        expect(searchInput).toHaveClass('focus-visible:ring-inset');
+    });
+
     it('passes refetch function to ToolBar for recipe updates', async () => {
         // Test that refetch is available for recipe image updates
         expect(true).toBe(true);


### PR DESCRIPTION
Shared Input component's focus-visible ring switches from an outside box-shadow to ring-inset, so it can never be clipped by an ancestor scroll container regardless of padding. Fixes the recipe search bar's cut-off focus outline; also covers the Add-from-Recipe drawer search input for free (shared component fix). Adds a component-level regression test plus a RecipesPage-level regression test.