### PR TITLE
fix(web): sync boot theme-color and add dark PWA manifest to stop flashbang

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -20,12 +20,23 @@
                     // Set background color directly
                     const bgColor = theme === 'dark' ? '#1a1a1a' : 'oklch(0.96 0.015 80)';
                     document.documentElement.style.setProperty('--initial-bg', bgColor);
+                    // Sync the theme-color meta tag so mobile browser/PWA chrome
+                    // matches immediately, instead of waiting for ThemeProvider
+                    // to mount after the async config load resolves.
+                    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+                    if (metaThemeColor) {
+                        metaThemeColor.setAttribute('content', theme === 'dark' ? '#1a1a1a' : '#2e7d32');
+                    }
                 } catch (e) {
                     // Fallback if localStorage fails
                     const theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
                     document.documentElement.classList.add(theme);
                     const bgColor = theme === 'dark' ? '#1a1a1a' : 'oklch(0.96 0.015 80)';
                     document.documentElement.style.setProperty('--initial-bg', bgColor);
+                    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+                    if (metaThemeColor) {
+                        metaThemeColor.setAttribute('content', theme === 'dark' ? '#1a1a1a' : '#2e7d32');
+                    }
                 }
             })();
         </script>

--- a/packages/web/public/manifest-dark.webmanifest
+++ b/packages/web/public/manifest-dark.webmanifest
@@ -1,35 +1,35 @@
 {
-    "name": "Shoppingo",
-    "short_name": "Shoppingo",
-    "description": "Shopping list application",
-    "start_url": "/",
-    "display": "standalone",
-    "background_color": "#1a1a1a",
-    "theme_color": "#1a1a1a",
-    "scope": "/",
-    "orientation": "portrait-primary",
-    "categories": ["shopping", "productivity", "lifestyle"],
-    "share_target": {
-        "action": "/share",
-        "method": "GET",
-        "params": {
-            "url": "url",
-            "title": "title",
-            "text": "text"
-        }
+  "name": "Shoppingo",
+  "short_name": "Shoppingo",
+  "description": "Shopping list application",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#1a1a1a",
+  "theme_color": "#1a1a1a",
+  "scope": "/",
+  "orientation": "portrait-primary",
+  "categories": ["shopping", "productivity", "lifestyle"],
+  "share_target": {
+    "action": "/share",
+    "method": "GET",
+    "params": {
+      "url": "url",
+      "title": "title",
+      "text": "text"
+    }
+  },
+  "icons": [
+    {
+      "src": "logo-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
     },
-    "icons": [
-        {
-            "src": "logo-192.png",
-            "sizes": "192x192",
-            "type": "image/png",
-            "purpose": "any maskable"
-        },
-        {
-            "src": "logo-512.png",
-            "sizes": "512x512",
-            "type": "image/png",
-            "purpose": "any maskable"
-        }
-    ]
+    {
+      "src": "logo-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
 }

--- a/packages/web/public/manifest-dark.webmanifest
+++ b/packages/web/public/manifest-dark.webmanifest
@@ -1,0 +1,35 @@
+{
+    "name": "Shoppingo",
+    "short_name": "Shoppingo",
+    "description": "Shopping list application",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#1a1a1a",
+    "theme_color": "#1a1a1a",
+    "scope": "/",
+    "orientation": "portrait-primary",
+    "categories": ["shopping", "productivity", "lifestyle"],
+    "share_target": {
+        "action": "/share",
+        "method": "GET",
+        "params": {
+            "url": "url",
+            "title": "title",
+            "text": "text"
+        }
+    },
+    "icons": [
+        {
+            "src": "logo-192.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "any maskable"
+        },
+        {
+            "src": "logo-512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "any maskable"
+        }
+    ]
+}

--- a/packages/web/src/boot/bootTheme.test.ts
+++ b/packages/web/src/boot/bootTheme.test.ts
@@ -18,16 +18,19 @@ const extractBootScript = (): string => {
 const bootScript = extractBootScript();
 
 const setSystemPrefersDark = (matches: boolean) => {
-    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
-        matches,
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-    } as MediaQueryList));
+    vi.spyOn(window, 'matchMedia').mockImplementation(
+        (query: string) =>
+            ({
+                matches,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            }) as MediaQueryList
+    );
 };
 
 describe('boot theme script (index.html)', () => {

--- a/packages/web/src/boot/bootTheme.test.ts
+++ b/packages/web/src/boot/bootTheme.test.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const indexHtmlPath = path.resolve(__dirname, '../../index.html');
+const indexHtml = fs.readFileSync(indexHtmlPath, 'utf-8');
+
+const extractBootScript = (): string => {
+    const match = indexHtml.match(/<script>\s*(\(function\(\) \{[\s\S]*?\}\)\(\);)\s*<\/script>/);
+    if (!match) {
+        throw new Error('Could not find boot theme IIFE in index.html');
+    }
+    return match[1];
+};
+
+const bootScript = extractBootScript();
+
+const setSystemPrefersDark = (matches: boolean) => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    } as MediaQueryList));
+};
+
+describe('boot theme script (index.html)', () => {
+    beforeEach(() => {
+        document.head.innerHTML = '<meta name="theme-color" content="#2e7d32" />';
+        document.documentElement.className = '';
+        document.documentElement.removeAttribute('style');
+        localStorage.clear();
+        setSystemPrefersDark(false);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('applies dark theme-color, class, and bg var when localStorage has "dark"', () => {
+        localStorage.setItem('theme', 'dark');
+
+        // eslint-disable-next-line no-new-func
+        new Function(bootScript)();
+
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        expect(document.documentElement.style.getPropertyValue('--initial-bg')).toBe('#1a1a1a');
+        expect(document.querySelector('meta[name="theme-color"]')?.getAttribute('content')).toBe('#1a1a1a');
+    });
+
+    it('applies light theme-color, class, and bg var when localStorage has "light"', () => {
+        localStorage.setItem('theme', 'light');
+
+        // eslint-disable-next-line no-new-func
+        new Function(bootScript)();
+
+        expect(document.documentElement.classList.contains('light')).toBe(true);
+        expect(document.documentElement.style.getPropertyValue('--initial-bg')).toBe('oklch(0.96 0.015 80)');
+        expect(document.querySelector('meta[name="theme-color"]')?.getAttribute('content')).toBe('#2e7d32');
+    });
+
+    it('falls back to system dark preference when nothing is stored', () => {
+        setSystemPrefersDark(true);
+
+        // eslint-disable-next-line no-new-func
+        new Function(bootScript)();
+
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        expect(document.querySelector('meta[name="theme-color"]')?.getAttribute('content')).toBe('#1a1a1a');
+    });
+});

--- a/packages/web/src/contexts/ThemeContext.tsx
+++ b/packages/web/src/contexts/ThemeContext.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
+import { applyManifestForTheme } from '../utils/applyManifestForTheme';
 
 type Theme = 'light' | 'dark';
 
@@ -56,6 +57,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         } catch (error) {
             console.warn('Failed to save theme preference:', error);
         }
+        applyManifestForTheme();
     };
 
     return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -16,6 +16,9 @@ import { getAuthConfig } from './config/auth';
 import { PullToRefreshProvider } from './contexts/PullToRefreshContext';
 import { PWAProvider } from './contexts/PWAContext';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { applyManifestForTheme } from './utils/applyManifestForTheme';
+
+applyManifestForTheme();
 
 const lazyLoadPage = (importFn: () => Promise<unknown>, fallbackName: string) =>
     React.lazy(() =>

--- a/packages/web/src/utils/applyManifestForTheme.test.ts
+++ b/packages/web/src/utils/applyManifestForTheme.test.ts
@@ -2,16 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { applyManifestForTheme } from './applyManifestForTheme';
 
 const setSystemPrefersDark = (matches: boolean) => {
-    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
-        matches,
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-    } as MediaQueryList));
+    vi.spyOn(window, 'matchMedia').mockImplementation(
+        (query: string) =>
+            ({
+                matches,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            }) as MediaQueryList
+    );
 };
 
 describe('applyManifestForTheme', () => {

--- a/packages/web/src/utils/applyManifestForTheme.test.ts
+++ b/packages/web/src/utils/applyManifestForTheme.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyManifestForTheme } from './applyManifestForTheme';
+
+const setSystemPrefersDark = (matches: boolean) => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    } as MediaQueryList));
+};
+
+describe('applyManifestForTheme', () => {
+    beforeEach(() => {
+        document.head.innerHTML = '<link rel="manifest" href="/manifest.webmanifest">';
+        localStorage.clear();
+        setSystemPrefersDark(false);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('points the manifest link at the dark manifest when theme is "dark"', () => {
+        localStorage.setItem('theme', 'dark');
+
+        applyManifestForTheme();
+
+        expect(document.querySelector('link[rel="manifest"]')?.getAttribute('href')).toBe('/manifest-dark.webmanifest');
+    });
+
+    it('points the manifest link at the light manifest when theme is "light"', () => {
+        localStorage.setItem('theme', 'light');
+
+        applyManifestForTheme();
+
+        expect(document.querySelector('link[rel="manifest"]')?.getAttribute('href')).toBe('/manifest.webmanifest');
+    });
+
+    it('falls back to system preference when nothing is stored', () => {
+        setSystemPrefersDark(true);
+
+        applyManifestForTheme();
+
+        expect(document.querySelector('link[rel="manifest"]')?.getAttribute('href')).toBe('/manifest-dark.webmanifest');
+    });
+
+    it('does nothing if no manifest link exists', () => {
+        document.head.innerHTML = '';
+        localStorage.setItem('theme', 'dark');
+
+        expect(() => applyManifestForTheme()).not.toThrow();
+    });
+});

--- a/packages/web/src/utils/applyManifestForTheme.ts
+++ b/packages/web/src/utils/applyManifestForTheme.ts
@@ -1,0 +1,28 @@
+const STORAGE_KEY = 'theme';
+
+type Theme = 'light' | 'dark';
+
+const resolveTheme = (): Theme => {
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored === 'light' || stored === 'dark') {
+            return stored;
+        }
+    } catch {
+        // localStorage unavailable, fall through to system preference
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+// Points the manifest link at the theme-appropriate variant so future
+// installs and browser manifest re-validations pick up matching native
+// splash-screen colors. Cannot repaint an already-cached splash for an
+// already-installed PWA instantly — browsers only revalidate periodically.
+export const applyManifestForTheme = (doc: Document = document): void => {
+    const link = doc.querySelector<HTMLLinkElement>('link[rel="manifest"]');
+    if (!link) {
+        return;
+    }
+    const theme = resolveTheme();
+    link.setAttribute('href', theme === 'dark' ? '/manifest-dark.webmanifest' : '/manifest.webmanifest');
+};

--- a/packages/web/src/utils/applyManifestForTheme.ts
+++ b/packages/web/src/utils/applyManifestForTheme.ts
@@ -2,16 +2,21 @@ const STORAGE_KEY = 'theme';
 
 type Theme = 'light' | 'dark';
 
-const resolveTheme = (): Theme => {
+const isTheme = (value: string | null): value is Theme => value === 'light' || value === 'dark';
+
+const getSystemTheme = (): Theme => (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
+const readStoredTheme = (): string | null => {
     try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored === 'light' || stored === 'dark') {
-            return stored;
-        }
+        return localStorage.getItem(STORAGE_KEY);
     } catch {
-        // localStorage unavailable, fall through to system preference
+        return null;
     }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+const resolveTheme = (): Theme => {
+    const stored = readStoredTheme();
+    return isTheme(stored) ? stored : getSystemTheme();
 };
 
 // Points the manifest link at the theme-appropriate variant so future


### PR DESCRIPTION
Fixes two independent boot/splash theming bugs (plan: ~/.claude/plans/shoppingo-pea-loading-theme.md):

1. The synchronous boot IIFE in index.html now also syncs `<meta name="theme-color">` in the same pass that primes `<html>` class + `--initial-bg`, so mobile browser/PWA chrome color is correct from the first frame instead of only after ThemeProvider mounts post-config-load.
2. Adds a dark-aware PWA manifest variant (manifest-dark.webmanifest) and swaps `<link rel="manifest">` to it at bootstrap and on every manual theme toggle, so future installs/manifest revalidations get a dark-appropriate native splash instead of the hardcoded light cream (#f7f1e7).

Known limitation (explicitly accepted per plan): manifest colors can't repaint an already-cached splash for an already-installed PWA instantly — only affects future installs/revalidation.

All new + existing web tests pass (415/415), tsc clean, both builds succeed, dark manifest confirmed present + precached in build output.