### PR TITLE
fix(web): swap each section's own toolbar icon for back, harden search-input autofill

### DIFF
--- a/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.test.tsx
+++ b/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.test.tsx
@@ -33,6 +33,6 @@ describe('AddFromRecipeDrawer', () => {
         expect(searchInput).toHaveAttribute('autocomplete', 'off');
         expect(searchInput).toHaveAttribute('name', 'add-from-recipe-search');
         expect(searchInput).toHaveAttribute('inputmode', 'search');
-        expect(searchInput).not.toHaveAttribute('type', 'search');
+        expect(searchInput).toHaveAttribute('type', 'search');
     });
 });

--- a/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.tsx
+++ b/packages/web/src/components/ToolBar/AddFromRecipeDrawer/index.tsx
@@ -149,10 +149,11 @@ export const AddFromRecipeDrawer = ({
                                 <div className="relative mb-3">
                                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
                                     <Input
+                                        type="search"
                                         value={recipeSearch}
                                         onChange={(e) => setRecipeSearch(e.target.value)}
                                         placeholder="Search recipes..."
-                                        className="pl-9 pr-9"
+                                        className="pl-9 pr-9 [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden"
                                         name="add-from-recipe-search"
                                         autoComplete="off"
                                         inputMode="search"

--- a/packages/web/src/components/ToolBar/ToolBarAppBar/index.test.tsx
+++ b/packages/web/src/components/ToolBar/ToolBarAppBar/index.test.tsx
@@ -78,6 +78,41 @@ describe('ToolBarAppBar', () => {
         expect(recipesButton).toBeDefined();
     });
 
+    it('shows back button on recipe detail page, in the Recipes slot', async () => {
+        const { ToolBarAppBar } = await import('./index');
+        const { container } = renderWithRouter(
+            <ToolBarAppBar isItemsPage={false} isListsPage={false} isRecipeDetailPage={true} onMenuClick={() => {}} />
+        );
+
+        const buttons = container.querySelectorAll('button');
+        const backButton = Array.from(buttons).find((btn) => btn.title.includes('back'));
+        expect(backButton).toBeDefined();
+        const recipesButton = Array.from(buttons).find((btn) => btn.title === 'Recipes');
+        expect(recipesButton).toBeUndefined();
+    });
+
+    it('still shows Shopping lists button on recipe detail page (only Recipes slot swaps)', async () => {
+        const { ToolBarAppBar } = await import('./index');
+        const { container } = renderWithRouter(
+            <ToolBarAppBar isItemsPage={false} isListsPage={false} isRecipeDetailPage={true} onMenuClick={() => {}} />
+        );
+
+        const buttons = container.querySelectorAll('button');
+        const shoppingListsButton = Array.from(buttons).find((btn) => btn.title === 'Shopping lists');
+        expect(shoppingListsButton).toBeDefined();
+    });
+
+    it('does not swap the Recipes slot for back on items page (only Shopping lists slot swaps)', async () => {
+        const { ToolBarAppBar } = await import('./index');
+        const { container } = renderWithRouter(
+            <ToolBarAppBar isItemsPage={true} isListsPage={false} onMenuClick={() => {}} />
+        );
+
+        const buttons = container.querySelectorAll('button');
+        const recipesButton = Array.from(buttons).find((btn) => btn.title === 'Recipes');
+        expect(recipesButton).toBeDefined();
+    });
+
     it('hides back button on lists page', async () => {
         const { ToolBarAppBar } = await import('./index');
         const { container } = renderWithRouter(

--- a/packages/web/src/components/ToolBar/ToolBarAppBar/index.tsx
+++ b/packages/web/src/components/ToolBar/ToolBarAppBar/index.tsx
@@ -52,12 +52,10 @@ export const ToolBarAppBar = forwardRef<HTMLDivElement, ToolBarAppBarProps>(
             }
         };
 
-        const showBackButton = isItemsPage || isRecipeDetailPage;
-
         return (
             <div ref={ref} className="flex w-full items-center justify-between py-2.5 px-3">
-                {/* Primary nav — Shopping lists slot swaps for back on drill-in pages */}
-                {showBackButton ? (
+                {/* Primary nav — each section's own slot swaps for back on its own drill-in page */}
+                {isItemsPage ? (
                     <ToolBarButton icon={ArrowLeft} title="Go back" onClick={handleGoBack} />
                 ) : (
                     <ToolBarButton
@@ -67,12 +65,16 @@ export const ToolBarAppBar = forwardRef<HTMLDivElement, ToolBarAppBarProps>(
                         active={isListsPage}
                     />
                 )}
-                <ToolBarButton
-                    icon={BookOpen}
-                    title="Recipes"
-                    onClick={() => navigate('/recipes')}
-                    active={isRecipesPage}
-                />
+                {isRecipeDetailPage ? (
+                    <ToolBarButton icon={ArrowLeft} title="Go back" onClick={handleGoBack} />
+                ) : (
+                    <ToolBarButton
+                        icon={BookOpen}
+                        title="Recipes"
+                        onClick={() => navigate('/recipes')}
+                        active={isRecipesPage}
+                    />
+                )}
                 <ToolBarButton
                     icon={Users}
                     title="Friends"

--- a/packages/web/src/pages/RecipesPage/index.test.tsx
+++ b/packages/web/src/pages/RecipesPage/index.test.tsx
@@ -75,7 +75,7 @@ describe('RecipesPage', () => {
         expect(searchInput).toHaveAttribute('autocomplete', 'off');
         expect(searchInput).toHaveAttribute('name', 'recipe-search');
         expect(searchInput).toHaveAttribute('inputmode', 'search');
-        expect(searchInput).not.toHaveAttribute('type', 'search');
+        expect(searchInput).toHaveAttribute('type', 'search');
     });
 
     it('renders the search input with an inset focus ring', () => {

--- a/packages/web/src/pages/RecipesPage/index.tsx
+++ b/packages/web/src/pages/RecipesPage/index.tsx
@@ -139,10 +139,11 @@ const RecipesPage = () => {
         <div className="relative mt-6">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             <Input
+                type="search"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search recipes..."
-                className="pl-9 pr-9"
+                className="pl-9 pr-9 [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden"
                 name="recipe-search"
                 autoComplete="off"
                 inputMode="search"


### PR DESCRIPTION
Corrects two regressions from PRs #118/#121 reported directly by the user.

1. Toolbar back-icon placement: PR #118 only fixed the *navigation logic* (real browser history via useGoBack), but the icon that swaps to a back arrow was still always the Shopping-lists slot (pre-existing behaviour from eb6d08a), even on Recipe Detail pages. Now each section's own toolbar slot swaps for back on its own drill-in page: Shopping-lists icon on Items pages, Recipes icon on Recipe Detail pages.

2. Recipe search autofill: PR #121 added autoComplete="off"/name/inputMode but that alone is ignored by Chrome/Android's native Address & Payment autofill heuristic. Added type="search" (the actual standards-based exclusion) to both recipe-search inputs, with WebKit's native search decorations suppressed via CSS so the existing custom clear-X button isn't duplicated.

Verified type="search" is present in the production build output (grepped the built JS bundle).