### PR TITLE
fix(web): recipe form autofill + reclaim wasted layout space

### DIFF
--- a/packages/web/src/components/Layout/index.tsx
+++ b/packages/web/src/components/Layout/index.tsx
@@ -16,15 +16,22 @@ interface LayoutProps {
 // no need for bottom-anchoring in the first place.
 const NORMAL_SCROLL_ROUTES = new Set(['/recipes']);
 
+// Routes with their own full-page header/footer (no bottom ToolBar) — they don't need
+// the bottom-24 space Layout normally reserves for it, or Layout's own padding.
+const FULL_BLEED_ROUTES = new Set(['/recipes/new']);
+
 export const Layout = ({ children }: LayoutProps) => {
     const { executeRefresh } = usePullToRefreshContext();
     const { scrollRef, pullY, isRefreshing, hasTriggered } = usePullToRefresh(executeRefresh);
     const { pathname } = useLocation();
 
     const flexDirectionClass = NORMAL_SCROLL_ROUTES.has(pathname) ? 'flex-col' : 'flex-col-reverse';
+    const containerClass = FULL_BLEED_ROUTES.has(pathname)
+        ? 'fixed top-14 md:top-16 bottom-0 left-0 right-0'
+        : 'fixed top-14 md:top-16 bottom-24 left-0 right-0 px-4 py-2 max-w-[500px] mx-auto';
 
     return (
-        <div className="fixed top-14 md:top-16 bottom-24 left-0 right-0 px-4 py-2 max-w-[500px] mx-auto">
+        <div className={containerClass}>
             <PullToRefreshIndicator pullY={pullY} isRefreshing={isRefreshing} hasTriggered={hasTriggered} />
             <div ref={scrollRef} className={`h-full overflow-y-auto flex ${flexDirectionClass} overscroll-y-contain`}>
                 {children}

--- a/packages/web/src/pages/AddRecipePage/ImportScreen.tsx
+++ b/packages/web/src/pages/AddRecipePage/ImportScreen.tsx
@@ -42,11 +42,13 @@ export const ImportScreen = ({
                         <Input
                             id={linkInputId}
                             type="url"
+                            name="recipe-link"
                             placeholder="https://..."
                             value={link}
                             onChange={(e) => setLink(e.target.value)}
                             disabled={isImporting}
                             autoFocus
+                            autoComplete="off"
                             className="h-10 border border-foreground/30"
                         />
                     </div>

--- a/packages/web/src/pages/AddRecipePage/LinkImportField.tsx
+++ b/packages/web/src/pages/AddRecipePage/LinkImportField.tsx
@@ -41,10 +41,12 @@ export const LinkImportField = ({
         <div className="flex gap-2">
             <Input
                 type="url"
+                name="recipe-link"
                 placeholder="https://..."
                 value={link}
                 onChange={(e) => setLink(e.target.value)}
                 disabled={disabled || isImporting}
+                autoComplete="off"
                 className="h-10 border border-foreground/30"
             />
             <Button

--- a/packages/web/src/pages/AddRecipePage/index.tsx
+++ b/packages/web/src/pages/AddRecipePage/index.tsx
@@ -258,7 +258,7 @@ const AddRecipePage = () => {
     };
 
     return (
-        <div className="flex flex-col min-h-[calc(100vh-3.5rem)]">
+        <div className="flex flex-col h-full">
             <AddRecipeHeader onCancel={handleCancel} disabled={isLoading} />
 
             <div className="flex-1 overflow-y-auto px-4">
@@ -267,6 +267,7 @@ const AddRecipePage = () => {
                         <Label htmlFor={recipeNameId}>Recipe Title</Label>
                         <Input
                             id={recipeNameId}
+                            name="recipe-title"
                             placeholder="Enter recipe title..."
                             value={title}
                             onChange={(e) => {
@@ -275,6 +276,7 @@ const AddRecipePage = () => {
                             }}
                             disabled={isLoading}
                             autoFocus
+                            autoComplete="off"
                             className="h-10 border border-foreground/30"
                         />
                     </div>


### PR DESCRIPTION
## Summary
- Add `autoComplete="off"` + a `name` to the Recipe Title and Recipe Link inputs on `/recipes/new`, matching the existing recipe search bar's props — stops Android Chrome's saved address/card autofill suggestion bar on those fields.
- `Layout` no longer reserves `bottom-24`/outer padding for `/recipes/new` — that page has its own sticky header/footer (no bottom `ToolBar`), so the space was dead black area cutting into scrollable content.

## Test plan
- [x] `bun run tsc --noEmit`
- [x] `bun run --filter @shoppingo/web test` (AddRecipePage + Layout suites, 26/26 pass)
- [x] Verified visually via Chrome DevTools MCP Android emulation (390x844, mobile+touch, Pixel UA): before/after screenshots confirm the dead bottom gap is gone and Recipe Title is visible on load without scrolling